### PR TITLE
[IOSDOX-12797] Adding BundleID to utm_source parameter to deep link

### DIFF
--- a/Sources/DoximityDialerSDK/DoximityDialer.swift
+++ b/Sources/DoximityDialerSDK/DoximityDialer.swift
@@ -15,6 +15,7 @@ public struct DoximityDialer {
         static let doximityScheme = "doximity://"
         static let dialerTargetNumberPath = "dialer/call?target_number="
         static let appsFlyerID = "id393642611"
+        static let budnleID = Bundle.main.bundleIdentifier ?? "com.doximity.dialersdk"
     }
 
     private let application: OpenApplicationURL
@@ -28,7 +29,7 @@ public struct DoximityDialer {
     /// - Parameter phoneNumber: The 10-digit phone number `String` to dial
     public func dialPhoneNumber(_ phoneNumber: String) {
         if isDoximityInstalled {
-            guard let dialerURL = URL(string: "\(Constants.doximityScheme)\(Constants.dialerTargetNumberPath)\(phoneNumber)") else { return }
+            guard let dialerURL = URL(string: "\(Constants.doximityScheme)\(Constants.dialerTargetNumberPath)\(phoneNumber)&utm_source=\(Constants.budnleID)") else { return }
             openURL(dialerURL)
         } else {
             guard let url = doximityAppStoreURL else { return }

--- a/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
+++ b/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
@@ -20,7 +20,7 @@ final class DoximityDialerSDKTests: XCTestCase {
 
     func testDialPhoneNumber_WithDoximityNotInstalled_ShouldOpenAppStoreURL() {
         dialerCaller.dialPhoneNumber("1234567890")
-        XCTAssertEqual(mockApplication.lastURL, URL(string: "doximity://dialer/call?target_number=1234567890"))
+        XCTAssertEqual(mockApplication.lastURL, URL(string: "doximity://dialer/call?target_number=1234567890&utm_source=com.apple.dt.xctest.tool"))
     }
 
     func testDialPhoneNumber_WithDoximityInstalled_ShouldOpenCorrectURL() {


### PR DESCRIPTION
Adding BundleID to utm_source parameter to native deep link for tracking.