### PR TITLE
Fixes for Xcode 16.

### DIFF
--- a/Sources/DoximityDialerSDK/DoximityDialer.swift
+++ b/Sources/DoximityDialerSDK/DoximityDialer.swift
@@ -129,8 +129,13 @@ public final class DoximityDialerObjc: NSObject {
 
 // MARK: OpenApplicationURL protocol
 protocol OpenApplicationURL {
-    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?)
-    func canOpenURL(_ url: URL) -> Bool
+    func open(
+        _ url: URL,
+        options: [UIApplication.OpenExternalURLOptionsKey : Any],
+        completionHandler completion: (@MainActor @Sendable (Bool) -> Void)?
+    )
+
+    nonisolated func canOpenURL(_ url: URL) -> Bool
 }
 
 extension UIApplication: OpenApplicationURL { }

--- a/Tests/DoximityDialerSDKTests/MockApplication.swift
+++ b/Tests/DoximityDialerSDKTests/MockApplication.swift
@@ -6,11 +6,15 @@ final class MockApplication: OpenApplicationURL {
     var lastURL: URL?
     var canOpenURL = true
 
-    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey : Any] = [:], completionHandler completion: ((Bool) -> Void)? = nil) {
+    func open(
+        _ url: URL,
+        options: [UIApplication.OpenExternalURLOptionsKey : Any],
+        completionHandler completion: (@MainActor @Sendable (Bool) -> Void)?
+    ) {
         lastURL = url
     }
 
-    func canOpenURL(_ url: URL) -> Bool {
+    nonisolated func canOpenURL(_ url: URL) -> Bool {
         canOpenURL
     }
 }


### PR DESCRIPTION
- Updated `OpenApplicationURL` method signatures to match latest `UIApplication` API in Xcode 16.