### PR TITLE
Add CircleCI workflow that tests against an xcode version matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
               --package_path "." \
               --scheme "DoximityDialerSDK" \
               --device "iPhone" \
-              --clean --result_bundle true --output-types "none"
+              --clean --result_bundle true --output-types "junit"
       - run:
           name: Geneerate Test Results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
               --device "iPhone" \
               --clean --result_bundle true --output-types "junit"
       - run:
-          name: Geneerate Test Results
+          name: Generate Test Results
           command: |
             fastlane trainer --path "test_output" --output_directory "test_results"
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,7 @@ meta:
   xcode-versions: &xcode-versions
       matrix:
         parameters:
-          xcode-version:
-            - 16.0.0
-            - 16.1.0
-            - 16.2.0
+          xcode-version: ["16.0.0", "16.1.0", "16.2.0"]
 
 jobs:
   build_and_test:
@@ -19,8 +16,7 @@ jobs:
       xcode: << parameters.xcode-version >>
     steps:
       - checkout
-      # - run: fastlane setup_circle_ci
-      - run: fastlane scan --package_path "." --scheme "DoximityDialerSDK" --device "iPhone 16 Pro Max" --result_bundle true
+      - run: fastlane scan --package_path "." --scheme "DoximityDialerSDK" --device "iPhone" --result_bundle true --output-types "" --clean
       - run: fastlane trainer --path "test_output" --output_directory "test_results"
       - store_test_results:
           path: test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       xcode: << parameters.xcode-version >>
     steps:
       - checkout
-      - run: fastlane setup_circle_ci
+      # - run: fastlane setup_circle_ci
       - run: fastlane scan --package_path "." --scheme "DoximityDialerSDK" --device "iPhone 16 Pro Max" --result_bundle true
       - run: fastlane trainer --path "test_output" --output_directory "test_results"
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2.1
+
+meta:
+  xcode-versions: &xcode-versions
+      matrix:
+        parameters:
+          xcode-version:
+            - 16.0.0
+            - 16.1.0
+            - 16.2.0
+
+jobs:
+  build_and_test:
+    parameters:
+      xcode-version:
+        type: string
+        default: 16.2.0
+    macos:
+      xcode: << parameters.xcode-version >>
+    steps:
+      - checkout
+      - run: fastlane setup_circle_ci
+      - run: fastlane scan --package_path "." --scheme "DoximityDialerSDK" --device "iPhone 16 Pro Max" --result_bundle true
+      - run: fastlane trainer --path "test_output" --output_directory "test_results"
+      - store_test_results:
+          path: test_results
+
+workflows:
+  main:
+    jobs:
+      - build_and_test:
+          <<: *xcode-versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
               --package_path "." \
               --scheme "DoximityDialerSDK" \
               --device "iPhone" \
-              --result_bundle true --output-types "" --clean
+              --clean --result_bundle true --output-types "none"
       - run:
           name: Geneerate Test Results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,18 @@ jobs:
       xcode: << parameters.xcode-version >>
     steps:
       - checkout
-      - run: fastlane scan --package_path "." --scheme "DoximityDialerSDK" --device "iPhone" --result_bundle true --output-types "" --clean
-      - run: fastlane trainer --path "test_output" --output_directory "test_results"
+      - run:
+          name: Build and Test
+          command: |
+            fastlane scan \
+              --package_path "." \
+              --scheme "DoximityDialerSDK" \
+              --device "iPhone" \
+              --result_bundle true --output-types "" --clean
+      - run:
+          name: Geneerate Test Results
+          command: |
+            fastlane trainer --path "test_output" --output_directory "test_results"
       - store_test_results:
           path: test_results
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ DerivedData/
 
 # OS X
 .DS_Store
+
+# CI
+test_output
+test_results


### PR DESCRIPTION
https://doximity.atlassian.net/browse/IA-3876

To help avoid future defects when we upgrade Xcode versions, this PR implements a simple CircleCI workflow that tests against the 3 most recent Xcode GA versions.

To keep this as simple and low maintenance as possible, the following shortcuts are being taken:
- We're using the version of `fastlane` that is pre-installed on the CircleCI-hosted executor, and not installing our own via a `Gemfile`.
- We're using `fastlane scan` and `fastlane trainer` with fairly simple command-line params, and not adding a `fastlane/Fastfile` to define our own actions.
- We're using `iPhone` for the device - what `fastlane scan` will do with this is pick the first match it can find in the simulator list. This will differ by xcode version but it also means that the param will test on _something_ regardless of Xcode version, meaning we will not need to update it or have it differ based on which Xcode version we're testing with. We will simply test on the first iPhone simulator that `fastlane` can grab.

Given the above compromises, the array of Xcode versions we're testing with should be the only thing that needs to be updated on a regular basis.