### PR TITLE
Use Major/Minor Image Tags for Xcode, Tighten Up Test Device Selection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,14 @@ meta:
   xcode-versions: &xcode-versions
       matrix:
         parameters:
-          xcode-version: ["16.3.0", "16.4.0", "26.0.1"]
+          xcode-version: ["16.3.0", "16.4.0", "26.0"]
 
 jobs:
   build_and_test:
     parameters:
       xcode-version:
         type: string
-        default: 26.0.1
+        default: 26.0
     macos:
       xcode: << parameters.xcode-version >>
     resource_class: m4pro.medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
               iphone_num="17"
             fi
             echo "Setting test device to iPhone $iphone_num"
-            echo 'export TEST_DEVICE="iPhone ${iphone_num}"' >> $BASH_ENV
+            echo "export TEST_DEVICE=\"iPhone $iphone_num\"" >> $BASH_ENV
       - run:
           name: Build and Test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ meta:
   xcode-versions: &xcode-versions
       matrix:
         parameters:
-          xcode-version: ["16.3.0", "16.4.0", "26.0"]
+          xcode-version: ["16.3", "16.4", "26.0"]
 
 jobs:
   build_and_test:
@@ -15,16 +15,27 @@ jobs:
     macos:
       xcode: << parameters.xcode-version >>
     resource_class: m4pro.medium
+    environment:
+      XCODE_VERSION: << parameters.xcode-version >>
     steps:
       - checkout
       - run: xcodebuild -version
+      - run:
+          name: Set test device
+          command: |
+            # Use iPhone 17 for Xcode 26.x, iPhone 16 otherwise
+            if [[ "$XCODE_VERSION" =~ "26" ]]; then
+              echo 'export TEST_DEVICE="iPhone 17"' >> $BASH_ENV
+            else
+              echo 'export TEST_DEVICE="iPhone 16"' >> $BASH_ENV
+            fi
       - run:
           name: Build and Test
           command: |
             fastlane scan \
               --package_path "." \
               --scheme "DoximityDialerSDK" \
-              --device "iPhone" \
+              --device "$TEST_DEVICE" \
               --clean --result_bundle true --output-types "junit"
       - run:
           name: Generate Test Results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,12 @@ jobs:
           name: Set test device
           command: |
             # Use iPhone 17 for Xcode 26.x, iPhone 16 otherwise
+            iphone_num="16"
             if [[ "$XCODE_VERSION" =~ "26" ]]; then
-              echo 'export TEST_DEVICE="iPhone 17"' >> $BASH_ENV
-            else
-              echo 'export TEST_DEVICE="iPhone 16"' >> $BASH_ENV
+              iphone_num="17"
             fi
+            echo "Setting test device to iPhone $iphone_num"
+            echo 'export TEST_DEVICE="iPhone ${iphone_num}"' >> $BASH_ENV
       - run:
           name: Build and Test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,14 @@ meta:
   xcode-versions: &xcode-versions
       matrix:
         parameters:
-          xcode-version: ["16.3.0", "16.4.0", "26.0.0"]
+          xcode-version: ["16.3.0", "16.4.0", "26.0.1"]
 
 jobs:
   build_and_test:
     parameters:
       xcode-version:
         type: string
-        default: 26.0.0
+        default: 26.0.1
     macos:
       xcode: << parameters.xcode-version >>
     resource_class: m4pro.medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     parameters:
       xcode-version:
         type: string
-        default: 26.0
+        default: "26.0"
     macos:
       xcode: << parameters.xcode-version >>
     resource_class: m4pro.medium


### PR DESCRIPTION
https://doximity.atlassian.net/browse/IA-4967

This was prompted by the Xcode 26.0.1 release, but rather than wait for CircleCI to have an Xcode 26.0.1 image, let's just generalize to major.minor and we automatically pick up Xcode patch versions as they become available. 

Also, setting test device selection to `iPhone 17` for Xcode 26.x, and `iPhone 16` otherwise.