### PR TITLE
Add support for auto starting voice and video calls

### DIFF
--- a/Examples/DoximityDialerExample/DoximityDialerExample.xcodeproj/project.pbxproj
+++ b/Examples/DoximityDialerExample/DoximityDialerExample.xcodeproj/project.pbxproj
@@ -1,0 +1,381 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 60;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		5C632BD32EB2673D00871749 /* DoximityDialerSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 5C632BD22EB2673D00871749 /* DoximityDialerSDK */; };
+		DD0000010000000000000001 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000020000000000000001 /* AppDelegate.swift */; };
+		DD0000030000000000000001 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000040000000000000001 /* SceneDelegate.swift */; };
+		DD0000050000000000000001 /* MainMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000060000000000000001 /* MainMenuViewController.swift */; };
+		DD0000070000000000000001 /* SwiftExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000080000000000000001 /* SwiftExampleViewController.swift */; };
+		DD0000090000000000000001 /* ObjCExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DD0000100000000000000001 /* ObjCExampleViewController.m */; };
+		DD0000110000000000000001 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DD0000120000000000000001 /* Assets.xcassets */; };
+		DD0000150000000000000001 /* SwiftUIExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000160000000000000001 /* SwiftUIExampleView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		DD0000020000000000000001 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		DD0000040000000000000001 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		DD0000060000000000000001 /* MainMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenuViewController.swift; sourceTree = "<group>"; };
+		DD0000080000000000000001 /* SwiftExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExampleViewController.swift; sourceTree = "<group>"; };
+		DD0000100000000000000001 /* ObjCExampleViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCExampleViewController.m; sourceTree = "<group>"; };
+		DD0000120000000000000001 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		DD0000160000000000000001 /* SwiftUIExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIExampleView.swift; sourceTree = "<group>"; };
+		DD0000170000000000000001 /* DoximityDialerExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DoximityDialerExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD0000180000000000000001 /* ObjCExampleViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCExampleViewController.h; sourceTree = "<group>"; };
+		DD0000190000000000000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DD0000200000000000000001 /* DoximityDialerExample-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DoximityDialerExample-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		DD0000210000000000000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5C632BD32EB2673D00871749 /* DoximityDialerSDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		DD0000220000000000000001 = {
+			isa = PBXGroup;
+			children = (
+				DD0000230000000000000001 /* DoximityDialerExample */,
+				DD0000240000000000000001 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		DD0000230000000000000001 /* DoximityDialerExample */ = {
+			isa = PBXGroup;
+			children = (
+				DD0000020000000000000001 /* AppDelegate.swift */,
+				DD0000040000000000000001 /* SceneDelegate.swift */,
+				DD0000060000000000000001 /* MainMenuViewController.swift */,
+				DD0000160000000000000001 /* SwiftUIExampleView.swift */,
+				DD0000080000000000000001 /* SwiftExampleViewController.swift */,
+				DD0000180000000000000001 /* ObjCExampleViewController.h */,
+				DD0000100000000000000001 /* ObjCExampleViewController.m */,
+				DD0000200000000000000001 /* DoximityDialerExample-Bridging-Header.h */,
+				DD0000120000000000000001 /* Assets.xcassets */,
+				DD0000190000000000000001 /* Info.plist */,
+			);
+			path = DoximityDialerExample;
+			sourceTree = "<group>";
+		};
+		DD0000240000000000000001 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				DD0000170000000000000001 /* DoximityDialerExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		DD0000250000000000000001 /* DoximityDialerExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DD0000260000000000000001 /* Build configuration list for PBXNativeTarget "DoximityDialerExample" */;
+			buildPhases = (
+				DD0000270000000000000001 /* Sources */,
+				DD0000210000000000000001 /* Frameworks */,
+				DD0000280000000000000001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DoximityDialerExample;
+			packageProductDependencies = (
+				5C632BD22EB2673D00871749 /* DoximityDialerSDK */,
+			);
+			productName = DoximityDialerExample;
+			productReference = DD0000170000000000000001 /* DoximityDialerExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		DD0000290000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 2600;
+				TargetAttributes = {
+					DD0000250000000000000001 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = DD0000300000000000000001 /* Build configuration list for PBXProject "DoximityDialerExample" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = DD0000220000000000000001;
+			packageReferences = (
+				5C632BD12EB2673D00871749 /* XCLocalSwiftPackageReference "../../../CallWithDoxDialer" */,
+			);
+			productRefGroup = DD0000240000000000000001 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				DD0000250000000000000001 /* DoximityDialerExample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		DD0000280000000000000001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DD0000110000000000000001 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		DD0000270000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DD0000150000000000000001 /* SwiftUIExampleView.swift in Sources */,
+				DD0000070000000000000001 /* SwiftExampleViewController.swift in Sources */,
+				DD0000050000000000000001 /* MainMenuViewController.swift in Sources */,
+				DD0000010000000000000001 /* AppDelegate.swift in Sources */,
+				DD0000030000000000000001 /* SceneDelegate.swift in Sources */,
+				DD0000090000000000000001 /* ObjCExampleViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		DD0000320000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		DD0000330000000000000001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		DD0000340000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = DoximityDialerExample/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.doximity.DoximityDialerExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "DoximityDialerExample/DoximityDialerExample-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		DD0000350000000000000001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = DoximityDialerExample/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.doximity.DoximityDialerExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "DoximityDialerExample/DoximityDialerExample-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		DD0000260000000000000001 /* Build configuration list for PBXNativeTarget "DoximityDialerExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DD0000340000000000000001 /* Debug */,
+				DD0000350000000000000001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DD0000300000000000000001 /* Build configuration list for PBXProject "DoximityDialerExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DD0000320000000000000001 /* Debug */,
+				DD0000330000000000000001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		5C632BD12EB2673D00871749 /* XCLocalSwiftPackageReference "../../../CallWithDoxDialer" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../../CallWithDoxDialer;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		5C632BD22EB2673D00871749 /* DoximityDialerSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DoximityDialerSDK;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = DD0000290000000000000001 /* Project object */;
+}

--- a/Examples/DoximityDialerExample/DoximityDialerExample/AppDelegate.swift
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/AppDelegate.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+}

--- a/Examples/DoximityDialerExample/DoximityDialerExample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/DoximityDialerExample/DoximityDialerExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/DoximityDialerExample/DoximityDialerExample/Assets.xcassets/Contents.json
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/DoximityDialerExample/DoximityDialerExample/DoximityDialerExample-Bridging-Header.h
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/DoximityDialerExample-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "ObjCExampleViewController.h"

--- a/Examples/DoximityDialerExample/DoximityDialerExample/Info.plist
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/Info.plist
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Doximity Example</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UIImageName</key>
+		<string></string>
+		<key>UIColorName</key>
+		<string></string>
+	</dict>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>doximity</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/DoximityDialerExample/DoximityDialerExample/MainMenuViewController.swift
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/MainMenuViewController.swift
@@ -94,11 +94,16 @@ class MainMenuViewController: UIViewController {
         setupActions()
         loadDoximityIcon()
         updateInstallationStatus()
+        setupNotificationObservers()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         updateInstallationStatus()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     // MARK: - Setup
@@ -169,6 +174,15 @@ class MainMenuViewController: UIViewController {
         objcExampleButton.addTarget(self, action: #selector(didTapObjCExample), for: .touchUpInside)
     }
 
+    private func setupNotificationObservers() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAppDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+
     private func loadDoximityIcon() {
         do {
             let icon = try DoximityDialer.shared.doximityIcon()
@@ -189,6 +203,10 @@ class MainMenuViewController: UIViewController {
             statusLabel.text = "Doximity is not installed"
             statusLabel.textColor = .systemOrange
         }
+    }
+
+    @objc private func handleAppDidBecomeActive() {
+        updateInstallationStatus()
     }
 
     // MARK: - Actions

--- a/Examples/DoximityDialerExample/DoximityDialerExample/MainMenuViewController.swift
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/MainMenuViewController.swift
@@ -1,0 +1,211 @@
+import UIKit
+import SwiftUI
+import DoximityDialerSDK
+
+/// Main menu for choosing between SwiftUI, UIKit (Swift), and Objective-C examples.
+class MainMenuViewController: UIViewController {
+
+    // MARK: - UI Components
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Doximity Dialer SDK"
+        label.font = .systemFont(ofSize: 32, weight: .bold)
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Example App"
+        label.font = .systemFont(ofSize: 18, weight: .regular)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let doximityIconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let statusLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.font = .systemFont(ofSize: 14, weight: .medium)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let swiftUIExampleButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("SwiftUI Example", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
+        button.backgroundColor = .systemIndigo
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 12
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private let swiftExampleButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("UIKit (Swift) Example", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
+        button.backgroundColor = .systemBlue
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 12
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private let objcExampleButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("UIKit (Objective-C) Example", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
+        button.backgroundColor = .systemOrange
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 12
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "This app demonstrates the DoximityDialerSDK integration in SwiftUI, UIKit (Swift), and UIKit (Objective-C).\n\nChoose an example to see how to integrate the SDK into your app."
+        label.font = .systemFont(ofSize: 14)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupActions()
+        loadDoximityIcon()
+        updateInstallationStatus()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        updateInstallationStatus()
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        view.backgroundColor = .systemBackground
+        title = "Doximity Dialer SDK"
+
+        view.addSubview(doximityIconImageView)
+        view.addSubview(titleLabel)
+        view.addSubview(subtitleLabel)
+        view.addSubview(statusLabel)
+        view.addSubview(swiftUIExampleButton)
+        view.addSubview(swiftExampleButton)
+        view.addSubview(objcExampleButton)
+        view.addSubview(descriptionLabel)
+
+        NSLayoutConstraint.activate([
+            // Icon
+            doximityIconImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 40),
+            doximityIconImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            doximityIconImageView.widthAnchor.constraint(equalToConstant: 100),
+            doximityIconImageView.heightAnchor.constraint(equalToConstant: 100),
+
+            // Title
+            titleLabel.topAnchor.constraint(equalTo: doximityIconImageView.bottomAnchor, constant: 24),
+            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            titleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+
+            // Subtitle
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
+            subtitleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            subtitleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+
+            // Status
+            statusLabel.topAnchor.constraint(equalTo: subtitleLabel.bottomAnchor, constant: 24),
+            statusLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            statusLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+
+            // SwiftUI Example Button
+            swiftUIExampleButton.topAnchor.constraint(equalTo: statusLabel.bottomAnchor, constant: 40),
+            swiftUIExampleButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40),
+            swiftUIExampleButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40),
+            swiftUIExampleButton.heightAnchor.constraint(equalToConstant: 56),
+
+            // UIKit Swift Example Button
+            swiftExampleButton.topAnchor.constraint(equalTo: swiftUIExampleButton.bottomAnchor, constant: 12),
+            swiftExampleButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40),
+            swiftExampleButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40),
+            swiftExampleButton.heightAnchor.constraint(equalToConstant: 56),
+
+            // Objective-C Example Button
+            objcExampleButton.topAnchor.constraint(equalTo: swiftExampleButton.bottomAnchor, constant: 12),
+            objcExampleButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40),
+            objcExampleButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40),
+            objcExampleButton.heightAnchor.constraint(equalToConstant: 56),
+
+            // Description
+            descriptionLabel.topAnchor.constraint(equalTo: objcExampleButton.bottomAnchor, constant: 32),
+            descriptionLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40),
+            descriptionLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40),
+        ])
+    }
+
+    private func setupActions() {
+        swiftUIExampleButton.addTarget(self, action: #selector(didTapSwiftUIExample), for: .touchUpInside)
+        swiftExampleButton.addTarget(self, action: #selector(didTapSwiftExample), for: .touchUpInside)
+        objcExampleButton.addTarget(self, action: #selector(didTapObjCExample), for: .touchUpInside)
+    }
+
+    private func loadDoximityIcon() {
+        do {
+            let icon = try DoximityDialer.shared.doximityIcon()
+            doximityIconImageView.image = icon
+        } catch {
+            print("Failed to load Doximity icon: \(error)")
+            doximityIconImageView.isHidden = true
+        }
+    }
+
+    private func updateInstallationStatus() {
+        let isInstalled = DoximityDialer.shared.isDoximityInstalled
+
+        if isInstalled {
+            statusLabel.text = "✓ Doximity is installed"
+            statusLabel.textColor = .systemGreen
+        } else {
+            statusLabel.text = "Doximity is not installed"
+            statusLabel.textColor = .systemOrange
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc private func didTapSwiftUIExample() {
+        let swiftUIView = SwiftUIExampleView()
+        let hostingController = UIHostingController(rootView: swiftUIView)
+        navigationController?.pushViewController(hostingController, animated: true)
+    }
+
+    @objc private func didTapSwiftExample() {
+        let swiftVC = SwiftExampleViewController()
+        navigationController?.pushViewController(swiftVC, animated: true)
+    }
+
+    @objc private func didTapObjCExample() {
+        let objcVC = ObjCExampleViewController()
+        navigationController?.pushViewController(objcVC, animated: true)
+    }
+}

--- a/Examples/DoximityDialerExample/DoximityDialerExample/ObjCExampleViewController.h
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/ObjCExampleViewController.h
@@ -1,0 +1,6 @@
+#import <UIKit/UIKit.h>
+
+/// Objective-C example demonstrating DoximityDialerSDK integration.
+@interface ObjCExampleViewController : UIViewController
+
+@end

--- a/Examples/DoximityDialerExample/DoximityDialerExample/ObjCExampleViewController.m
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/ObjCExampleViewController.m
@@ -26,11 +26,16 @@
     [self setupActions];
     [self loadDoximityIcon];
     [self updateUIForInstallationStatus];
+    [self setupNotificationObservers];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     [self updateUIForInstallationStatus];
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 #pragma mark - Setup
@@ -211,6 +216,13 @@
     [self.view addGestureRecognizer:tapGesture];
 }
 
+- (void)setupNotificationObservers {
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleAppDidBecomeActive)
+                                                 name:UIApplicationDidBecomeActiveNotification
+                                               object:nil];
+}
+
 #pragma mark - Doximity Icon
 
 - (void)loadDoximityIcon {
@@ -249,6 +261,10 @@
         self.statusLabel.text = @"Doximity is not installed\nInstall it to make calls";
         self.statusLabel.textColor = UIColor.systemRedColor;
     }
+}
+
+- (void)handleAppDidBecomeActive {
+    [self updateUIForInstallationStatus];
 }
 
 #pragma mark - Actions

--- a/Examples/DoximityDialerExample/DoximityDialerExample/ObjCExampleViewController.m
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/ObjCExampleViewController.m
@@ -1,0 +1,310 @@
+#import "ObjCExampleViewController.h"
+@import DoximityDialerSDK;
+
+@interface ObjCExampleViewController ()
+
+@property (nonatomic, strong) UIScrollView *scrollView;
+@property (nonatomic, strong) UIView *contentView;
+@property (nonatomic, strong) UIImageView *doximityIconImageView;
+@property (nonatomic, strong) UILabel *statusLabel;
+@property (nonatomic, strong) UITextField *phoneNumberTextField;
+@property (nonatomic, strong) UIButton *prefillButton;
+@property (nonatomic, strong) UIButton *voiceCallButton;
+@property (nonatomic, strong) UIButton *videoCallButton;
+@property (nonatomic, strong) UIButton *installDoximityButton;
+@property (nonatomic, strong) UILabel *instructionsLabel;
+
+@end
+
+@implementation ObjCExampleViewController
+
+#pragma mark - Lifecycle
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    [self setupUI];
+    [self setupActions];
+    [self loadDoximityIcon];
+    [self updateUIForInstallationStatus];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self updateUIForInstallationStatus];
+}
+
+#pragma mark - Setup
+
+- (void)setupUI {
+    self.view.backgroundColor = UIColor.systemBackgroundColor;
+    self.title = @"Objective-C Example";
+
+    // Initialize views
+    [self initializeViews];
+
+    // Add hierarchy
+    [self.view addSubview:self.scrollView];
+    [self.scrollView addSubview:self.contentView];
+
+    [self.contentView addSubview:self.doximityIconImageView];
+    [self.contentView addSubview:self.statusLabel];
+    [self.contentView addSubview:self.phoneNumberTextField];
+    [self.contentView addSubview:self.prefillButton];
+    [self.contentView addSubview:self.voiceCallButton];
+    [self.contentView addSubview:self.videoCallButton];
+    [self.contentView addSubview:self.installDoximityButton];
+    [self.contentView addSubview:self.instructionsLabel];
+
+    // Layout
+    [self setupConstraints];
+}
+
+- (void)initializeViews {
+    // ScrollView
+    self.scrollView = [[UIScrollView alloc] init];
+    self.scrollView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    // ContentView
+    self.contentView = [[UIView alloc] init];
+    self.contentView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    // Icon ImageView
+    self.doximityIconImageView = [[UIImageView alloc] init];
+    self.doximityIconImageView.contentMode = UIViewContentModeScaleAspectFit;
+    self.doximityIconImageView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    // Status Label
+    self.statusLabel = [[UILabel alloc] init];
+    self.statusLabel.textAlignment = NSTextAlignmentCenter;
+    self.statusLabel.numberOfLines = 0;
+    self.statusLabel.font = [UIFont systemFontOfSize:16 weight:UIFontWeightMedium];
+    self.statusLabel.translatesAutoresizingMaskIntoConstraints = NO;
+
+    // Phone Number TextField
+    self.phoneNumberTextField = [[UITextField alloc] init];
+    self.phoneNumberTextField.placeholder = @"Enter phone number";
+    self.phoneNumberTextField.borderStyle = UITextBorderStyleRoundedRect;
+    self.phoneNumberTextField.keyboardType = UIKeyboardTypePhonePad;
+    self.phoneNumberTextField.text = @"";
+    self.phoneNumberTextField.font = [UIFont systemFontOfSize:16];
+    self.phoneNumberTextField.translatesAutoresizingMaskIntoConstraints = NO;
+
+    // Prefill Button
+    self.prefillButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.prefillButton setTitle:@"Call with Doximity (Prefill)" forState:UIControlStateNormal];
+    self.prefillButton.titleLabel.font = [UIFont systemFontOfSize:16 weight:UIFontWeightSemibold];
+    self.prefillButton.backgroundColor = UIColor.systemBlueColor;
+    [self.prefillButton setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
+    self.prefillButton.layer.cornerRadius = 12;
+    self.prefillButton.translatesAutoresizingMaskIntoConstraints = NO;
+
+    // Voice Call Button
+    self.voiceCallButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.voiceCallButton setTitle:@"Start Voice Call" forState:UIControlStateNormal];
+    self.voiceCallButton.titleLabel.font = [UIFont systemFontOfSize:16 weight:UIFontWeightSemibold];
+    self.voiceCallButton.backgroundColor = UIColor.systemGreenColor;
+    [self.voiceCallButton setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
+    self.voiceCallButton.layer.cornerRadius = 12;
+    self.voiceCallButton.translatesAutoresizingMaskIntoConstraints = NO;
+
+    // Video Call Button
+    self.videoCallButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.videoCallButton setTitle:@"Start Video Call" forState:UIControlStateNormal];
+    self.videoCallButton.titleLabel.font = [UIFont systemFontOfSize:16 weight:UIFontWeightSemibold];
+    self.videoCallButton.backgroundColor = UIColor.systemPurpleColor;
+    [self.videoCallButton setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
+    self.videoCallButton.layer.cornerRadius = 12;
+    self.videoCallButton.translatesAutoresizingMaskIntoConstraints = NO;
+
+    // Install Button
+    self.installDoximityButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.installDoximityButton setTitle:@"Install Doximity" forState:UIControlStateNormal];
+    self.installDoximityButton.titleLabel.font = [UIFont systemFontOfSize:16 weight:UIFontWeightSemibold];
+    self.installDoximityButton.backgroundColor = UIColor.systemOrangeColor;
+    [self.installDoximityButton setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
+    self.installDoximityButton.layer.cornerRadius = 12;
+    self.installDoximityButton.translatesAutoresizingMaskIntoConstraints = NO;
+
+    // Instructions Label
+    self.instructionsLabel = [[UILabel alloc] init];
+    self.instructionsLabel.textAlignment = NSTextAlignmentCenter;
+    self.instructionsLabel.numberOfLines = 0;
+    self.instructionsLabel.font = [UIFont systemFontOfSize:12];
+    self.instructionsLabel.textColor = UIColor.secondaryLabelColor;
+    self.instructionsLabel.text = @"This example demonstrates the DoximityDialerSDK in Objective-C.\n\nPrefill: Opens Doximity with the number, letting the user choose call type.\nVoice/Video: Automatically starts the selected call type.\n\nPhone numbers can be formatted any way:\n• 5551234567\n• (555) 123-4567\n• +1 (555) 123-4567";
+    self.instructionsLabel.translatesAutoresizingMaskIntoConstraints = NO;
+}
+
+- (void)setupConstraints {
+    [NSLayoutConstraint activateConstraints:@[
+        // ScrollView
+        [self.scrollView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor],
+        [self.scrollView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [self.scrollView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [self.scrollView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+
+        // ContentView
+        [self.contentView.topAnchor constraintEqualToAnchor:self.scrollView.topAnchor],
+        [self.contentView.leadingAnchor constraintEqualToAnchor:self.scrollView.leadingAnchor],
+        [self.contentView.trailingAnchor constraintEqualToAnchor:self.scrollView.trailingAnchor],
+        [self.contentView.bottomAnchor constraintEqualToAnchor:self.scrollView.bottomAnchor],
+        [self.contentView.widthAnchor constraintEqualToAnchor:self.scrollView.widthAnchor],
+
+        // Icon
+        [self.doximityIconImageView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:40],
+        [self.doximityIconImageView.centerXAnchor constraintEqualToAnchor:self.contentView.centerXAnchor],
+        [self.doximityIconImageView.widthAnchor constraintEqualToConstant:80],
+        [self.doximityIconImageView.heightAnchor constraintEqualToConstant:80],
+
+        // Status
+        [self.statusLabel.topAnchor constraintEqualToAnchor:self.doximityIconImageView.bottomAnchor constant:20],
+        [self.statusLabel.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:20],
+        [self.statusLabel.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-20],
+
+        // Phone Number
+        [self.phoneNumberTextField.topAnchor constraintEqualToAnchor:self.statusLabel.bottomAnchor constant:40],
+        [self.phoneNumberTextField.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:20],
+        [self.phoneNumberTextField.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-20],
+        [self.phoneNumberTextField.heightAnchor constraintEqualToConstant:50],
+
+        // Prefill Button
+        [self.prefillButton.topAnchor constraintEqualToAnchor:self.phoneNumberTextField.bottomAnchor constant:24],
+        [self.prefillButton.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:20],
+        [self.prefillButton.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-20],
+        [self.prefillButton.heightAnchor constraintEqualToConstant:56],
+
+        // Voice Call Button
+        [self.voiceCallButton.topAnchor constraintEqualToAnchor:self.prefillButton.bottomAnchor constant:12],
+        [self.voiceCallButton.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:20],
+        [self.voiceCallButton.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-20],
+        [self.voiceCallButton.heightAnchor constraintEqualToConstant:56],
+
+        // Video Call Button
+        [self.videoCallButton.topAnchor constraintEqualToAnchor:self.voiceCallButton.bottomAnchor constant:12],
+        [self.videoCallButton.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:20],
+        [self.videoCallButton.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-20],
+        [self.videoCallButton.heightAnchor constraintEqualToConstant:56],
+
+        // Install Button
+        [self.installDoximityButton.topAnchor constraintEqualToAnchor:self.videoCallButton.bottomAnchor constant:12],
+        [self.installDoximityButton.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:20],
+        [self.installDoximityButton.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-20],
+        [self.installDoximityButton.heightAnchor constraintEqualToConstant:56],
+
+        // Instructions
+        [self.instructionsLabel.topAnchor constraintEqualToAnchor:self.installDoximityButton.bottomAnchor constant:40],
+        [self.instructionsLabel.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:20],
+        [self.instructionsLabel.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-20],
+        [self.instructionsLabel.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor constant:-40],
+    ]];
+}
+
+- (void)setupActions {
+    [self.prefillButton addTarget:self action:@selector(didTapPrefillButton) forControlEvents:UIControlEventTouchUpInside];
+    [self.voiceCallButton addTarget:self action:@selector(didTapVoiceCallButton) forControlEvents:UIControlEventTouchUpInside];
+    [self.videoCallButton addTarget:self action:@selector(didTapVideoCallButton) forControlEvents:UIControlEventTouchUpInside];
+    [self.installDoximityButton addTarget:self action:@selector(didTapInstallButton) forControlEvents:UIControlEventTouchUpInside];
+
+    // Dismiss keyboard when tapping outside
+    UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
+    tapGesture.cancelsTouchesInView = NO;
+    [self.view addGestureRecognizer:tapGesture];
+}
+
+#pragma mark - Doximity Icon
+
+- (void)loadDoximityIcon {
+    NSError *error = nil;
+    UIImage *icon = [DoximityDialer doximityIconAndReturnError:&error];
+    if (error) {
+        NSLog(@"Failed to load Doximity icon: %@", error);
+        self.doximityIconImageView.hidden = YES;
+    } else {
+        self.doximityIconImageView.image = icon;
+    }
+}
+
+#pragma mark - Installation Status
+
+- (void)updateUIForInstallationStatus {
+    BOOL isInstalled = [DoximityDialer isDoximityInstalled];
+
+    // Update button states
+    self.prefillButton.enabled = isInstalled;
+    self.voiceCallButton.enabled = isInstalled;
+    self.videoCallButton.enabled = isInstalled;
+    self.installDoximityButton.hidden = isInstalled;
+
+    // Update button appearance for disabled state
+    CGFloat alpha = isInstalled ? 1.0 : 0.5;
+    self.prefillButton.alpha = alpha;
+    self.voiceCallButton.alpha = alpha;
+    self.videoCallButton.alpha = alpha;
+
+    // Update status label
+    if (isInstalled) {
+        self.statusLabel.text = @"✓ Doximity is installed";
+        self.statusLabel.textColor = UIColor.systemGreenColor;
+    } else {
+        self.statusLabel.text = @"Doximity is not installed\nInstall it to make calls";
+        self.statusLabel.textColor = UIColor.systemRedColor;
+    }
+}
+
+#pragma mark - Actions
+
+- (void)didTapPrefillButton {
+    NSString *phoneNumber = self.phoneNumberTextField.text;
+    if (!phoneNumber || phoneNumber.length == 0) {
+        [self showAlertWithTitle:@"Error" message:@"Please enter a phone number"];
+        return;
+    }
+
+    // Prefill the number in Doximity Dialer
+    // This lets the user choose whether to start a voice or video call
+    [DoximityDialer dialPhoneNumber:phoneNumber];
+}
+
+- (void)didTapVoiceCallButton {
+    NSString *phoneNumber = self.phoneNumberTextField.text;
+    if (!phoneNumber || phoneNumber.length == 0) {
+        [self showAlertWithTitle:@"Error" message:@"Please enter a phone number"];
+        return;
+    }
+
+    // Automatically start a voice call
+    [DoximityDialer startVoiceCall:phoneNumber];
+}
+
+- (void)didTapVideoCallButton {
+    NSString *phoneNumber = self.phoneNumberTextField.text;
+    if (!phoneNumber || phoneNumber.length == 0) {
+        [self showAlertWithTitle:@"Error" message:@"Please enter a phone number"];
+        return;
+    }
+
+    // Automatically start a video call
+    [DoximityDialer startVideoCall:phoneNumber];
+}
+
+- (void)didTapInstallButton {
+    // When Doximity is not installed, any dial method redirects to the App Store
+    // We can use any method to trigger the installation flow
+    [DoximityDialer dialPhoneNumber:@""];
+}
+
+- (void)dismissKeyboard {
+    [self.view endEditing:YES];
+}
+
+#pragma mark - Helper
+
+- (void)showAlertWithTitle:(NSString *)title message:(NSString *)message {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title
+                                                                   message:message
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+@end

--- a/Examples/DoximityDialerExample/DoximityDialerExample/SceneDelegate.swift
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/SceneDelegate.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+
+        window = UIWindow(windowScene: windowScene)
+
+        let mainMenuViewController = MainMenuViewController()
+        let navigationController = UINavigationController(rootViewController: mainMenuViewController)
+
+        window?.rootViewController = navigationController
+        window?.makeKeyAndVisible()
+    }
+}

--- a/Examples/DoximityDialerExample/DoximityDialerExample/SwiftExampleViewController.swift
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/SwiftExampleViewController.swift
@@ -124,11 +124,16 @@ class SwiftExampleViewController: UIViewController {
         setupActions()
         loadDoximityIcon()
         updateUIForInstallationStatus()
+        setupNotificationObservers()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         updateUIForInstallationStatus()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     // MARK: - Setup
@@ -226,6 +231,15 @@ class SwiftExampleViewController: UIViewController {
         view.addGestureRecognizer(tapGesture)
     }
 
+    private func setupNotificationObservers() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAppDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+
     // MARK: - Doximity Icon
 
     private func loadDoximityIcon() {
@@ -263,6 +277,10 @@ class SwiftExampleViewController: UIViewController {
             statusLabel.text = "Doximity is not installed\nInstall it to make calls"
             statusLabel.textColor = .systemRed
         }
+    }
+
+    @objc private func handleAppDidBecomeActive() {
+        updateUIForInstallationStatus()
     }
 
     // MARK: - Actions

--- a/Examples/DoximityDialerExample/DoximityDialerExample/SwiftExampleViewController.swift
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/SwiftExampleViewController.swift
@@ -1,0 +1,318 @@
+import UIKit
+import DoximityDialerSDK
+
+/// Swift example demonstrating DoximityDialerSDK integration.
+///
+/// This example shows:
+/// - Checking if Doximity is installed
+/// - Displaying the Doximity icon
+/// - Initiating calls with prefill, voice, and video options
+/// - Proper UI/UX patterns for integration
+class SwiftExampleViewController: UIViewController {
+
+    // MARK: - UI Components
+
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+
+    private let contentView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let doximityIconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let statusLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.font = .systemFont(ofSize: 16, weight: .medium)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let phoneNumberTextField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "Enter phone number"
+        textField.borderStyle = .roundedRect
+        textField.keyboardType = .phonePad
+        textField.text = ""
+        textField.font = .systemFont(ofSize: 16)
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        return textField
+    }()
+
+    private let prefillButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Call with Doximity (Prefill)", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
+        button.backgroundColor = .systemBlue
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 12
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private let voiceCallButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Start Voice Call", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
+        button.backgroundColor = .systemGreen
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 12
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private let videoCallButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Start Video Call", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
+        button.backgroundColor = .systemPurple
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 12
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private let installDoximityButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Install Doximity", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
+        button.backgroundColor = .systemOrange
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 12
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private let instructionsLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.font = .systemFont(ofSize: 12)
+        label.textColor = .secondaryLabel
+        label.text = """
+        This example demonstrates the DoximityDialerSDK in Swift.
+
+        Prefill: Opens Doximity with the number, letting the user choose call type.
+        Voice/Video: Automatically starts the selected call type.
+
+        Phone numbers can be formatted any way:
+        • 5551234567
+        • (555) 123-4567
+        • +1 (555) 123-4567
+        """
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupActions()
+        loadDoximityIcon()
+        updateUIForInstallationStatus()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        updateUIForInstallationStatus()
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        view.backgroundColor = .systemBackground
+        title = "Swift Example"
+
+        // Add hierarchy
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
+
+        contentView.addSubview(doximityIconImageView)
+        contentView.addSubview(statusLabel)
+        contentView.addSubview(phoneNumberTextField)
+        contentView.addSubview(prefillButton)
+        contentView.addSubview(voiceCallButton)
+        contentView.addSubview(videoCallButton)
+        contentView.addSubview(installDoximityButton)
+        contentView.addSubview(instructionsLabel)
+
+        // Layout
+        NSLayoutConstraint.activate([
+            // ScrollView
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            // ContentView
+            contentView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+
+            // Icon
+            doximityIconImageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 40),
+            doximityIconImageView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            doximityIconImageView.widthAnchor.constraint(equalToConstant: 80),
+            doximityIconImageView.heightAnchor.constraint(equalToConstant: 80),
+
+            // Status
+            statusLabel.topAnchor.constraint(equalTo: doximityIconImageView.bottomAnchor, constant: 20),
+            statusLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            statusLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+
+            // Phone Number
+            phoneNumberTextField.topAnchor.constraint(equalTo: statusLabel.bottomAnchor, constant: 40),
+            phoneNumberTextField.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            phoneNumberTextField.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            phoneNumberTextField.heightAnchor.constraint(equalToConstant: 50),
+
+            // Prefill Button
+            prefillButton.topAnchor.constraint(equalTo: phoneNumberTextField.bottomAnchor, constant: 24),
+            prefillButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            prefillButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            prefillButton.heightAnchor.constraint(equalToConstant: 56),
+
+            // Voice Call Button
+            voiceCallButton.topAnchor.constraint(equalTo: prefillButton.bottomAnchor, constant: 12),
+            voiceCallButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            voiceCallButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            voiceCallButton.heightAnchor.constraint(equalToConstant: 56),
+
+            // Video Call Button
+            videoCallButton.topAnchor.constraint(equalTo: voiceCallButton.bottomAnchor, constant: 12),
+            videoCallButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            videoCallButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            videoCallButton.heightAnchor.constraint(equalToConstant: 56),
+
+            // Install Button
+            installDoximityButton.topAnchor.constraint(equalTo: videoCallButton.bottomAnchor, constant: 12),
+            installDoximityButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            installDoximityButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            installDoximityButton.heightAnchor.constraint(equalToConstant: 56),
+
+            // Instructions
+            instructionsLabel.topAnchor.constraint(equalTo: installDoximityButton.bottomAnchor, constant: 40),
+            instructionsLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            instructionsLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            instructionsLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -40),
+        ])
+    }
+
+    private func setupActions() {
+        prefillButton.addTarget(self, action: #selector(didTapPrefillButton), for: .touchUpInside)
+        voiceCallButton.addTarget(self, action: #selector(didTapVoiceCallButton), for: .touchUpInside)
+        videoCallButton.addTarget(self, action: #selector(didTapVideoCallButton), for: .touchUpInside)
+        installDoximityButton.addTarget(self, action: #selector(didTapInstallButton), for: .touchUpInside)
+
+        // Dismiss keyboard when tapping outside
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
+    }
+
+    // MARK: - Doximity Icon
+
+    private func loadDoximityIcon() {
+        do {
+            let icon = try DoximityDialer.shared.doximityIcon()
+            doximityIconImageView.image = icon
+        } catch {
+            print("Failed to load Doximity icon: \(error)")
+            doximityIconImageView.isHidden = true
+        }
+    }
+
+    // MARK: - Installation Status
+
+    private func updateUIForInstallationStatus() {
+        let isInstalled = DoximityDialer.shared.isDoximityInstalled
+
+        // Update button states
+        prefillButton.isEnabled = isInstalled
+        voiceCallButton.isEnabled = isInstalled
+        videoCallButton.isEnabled = isInstalled
+        installDoximityButton.isHidden = isInstalled
+
+        // Update button appearance for disabled state
+        let alpha: CGFloat = isInstalled ? 1.0 : 0.5
+        prefillButton.alpha = alpha
+        voiceCallButton.alpha = alpha
+        videoCallButton.alpha = alpha
+
+        // Update status label
+        if isInstalled {
+            statusLabel.text = "✓ Doximity is installed"
+            statusLabel.textColor = .systemGreen
+        } else {
+            statusLabel.text = "Doximity is not installed\nInstall it to make calls"
+            statusLabel.textColor = .systemRed
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc private func didTapPrefillButton() {
+        guard let phoneNumber = phoneNumberTextField.text, !phoneNumber.isEmpty else {
+            showAlert(title: "Error", message: "Please enter a phone number")
+            return
+        }
+
+        // Prefill the number in Doximity Dialer
+        // This lets the user choose whether to start a voice or video call
+        DoximityDialer.shared.dialPhoneNumber(phoneNumber)
+    }
+
+    @objc private func didTapVoiceCallButton() {
+        guard let phoneNumber = phoneNumberTextField.text, !phoneNumber.isEmpty else {
+            showAlert(title: "Error", message: "Please enter a phone number")
+            return
+        }
+
+        // Automatically start a voice call
+        DoximityDialer.shared.startVoiceCall(phoneNumber)
+    }
+
+    @objc private func didTapVideoCallButton() {
+        guard let phoneNumber = phoneNumberTextField.text, !phoneNumber.isEmpty else {
+            showAlert(title: "Error", message: "Please enter a phone number")
+            return
+        }
+
+        // Automatically start a video call
+        DoximityDialer.shared.startVideoCall(phoneNumber)
+    }
+
+    @objc private func didTapInstallButton() {
+        // When Doximity is not installed, any dial method redirects to the App Store
+        // We can use any method to trigger the installation flow
+        DoximityDialer.shared.dialPhoneNumber("")
+    }
+
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
+    }
+
+    // MARK: - Helper
+
+    private func showAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+}

--- a/Examples/DoximityDialerExample/DoximityDialerExample/SwiftUIExampleView.swift
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/SwiftUIExampleView.swift
@@ -1,0 +1,161 @@
+import SwiftUI
+import DoximityDialerSDK
+
+struct SwiftUIExampleView: View {
+    @State private var phoneNumber = ""
+    @State private var doximityIcon: UIImage?
+    @State private var showError = false
+    @State private var errorMessage = ""
+
+    private let isDoximityInstalled = DoximityDialer.shared.isDoximityInstalled
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                // Header
+                VStack(spacing: 16) {
+                    if let icon = doximityIcon {
+                        Image(uiImage: icon)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 80, height: 80)
+                    }
+
+                    Text(isDoximityInstalled ? "✓ Doximity is installed" : "Doximity is not installed")
+                        .font(.body)
+                        .foregroundColor(isDoximityInstalled ? .green : .orange)
+                }
+                .padding(.top, 40)
+
+                // Phone Number Input
+                TextField("Enter phone number", text: $phoneNumber)
+                    .textFieldStyle(.roundedBorder)
+                    .keyboardType(.phonePad)
+                    .autocorrectionDisabled()
+                    .padding(.horizontal, 32)
+
+                // Action Buttons
+                VStack(spacing: 16) {
+                    Button {
+                        dialNumber()
+                    } label: {
+                        Text("Call with Doximity (Prefill)")
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 56)
+                            .background(Color.blue)
+                            .cornerRadius(12)
+                    }
+
+                    Button {
+                        startVoiceCall()
+                    } label: {
+                        Text("Start Voice Call")
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 56)
+                            .background(Color.green)
+                            .cornerRadius(12)
+                    }
+
+                    Button {
+                        startVideoCall()
+                    } label: {
+                        Text("Start Video Call")
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 56)
+                            .background(Color.purple)
+                            .cornerRadius(12)
+                    }
+                }
+                .padding(.horizontal, 32)
+
+                Spacer(minLength: 40)
+
+                // Description
+                VStack(spacing: 16) {
+                    Text("This example demonstrates the DoximityDialerSDK in SwiftUI.")
+                        .font(.system(size: 14))
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Prefill: Opens Doximity with the number, letting the user choose call type.")
+                            .font(.system(size: 14))
+                            .foregroundColor(.secondary)
+
+                        Text("Voice/Video: Automatically starts the selected call type.")
+                            .font(.system(size: 14))
+                            .foregroundColor(.secondary)
+                    }
+                    .multilineTextAlignment(.center)
+
+                    VStack(spacing: 4) {
+                        Text("Phone numbers can be formatted any way:")
+                            .font(.system(size: 14))
+                            .foregroundColor(.secondary)
+
+                        Text("• 5551234567")
+                            .font(.system(size: 14))
+                            .foregroundColor(.secondary)
+
+                        Text("• (555) 123-4567")
+                            .font(.system(size: 14))
+                            .foregroundColor(.secondary)
+
+                        Text("• +1 (555) 123-4567")
+                            .font(.system(size: 14))
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .padding(.horizontal, 40)
+                .padding(.bottom, 40)
+            }
+        }
+        .navigationTitle("SwiftUI Example")
+        .navigationBarTitleDisplayMode(.inline)
+        .alert("Error", isPresented: $showError) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(errorMessage)
+        }
+        .onAppear {
+            loadIcon()
+        }
+    }
+
+    // MARK: - Actions
+
+    private func dialNumber() {
+        DoximityDialer.shared.dialPhoneNumber(phoneNumber)
+    }
+
+    private func startVoiceCall() {
+        DoximityDialer.shared.startVoiceCall(phoneNumber)
+    }
+
+    private func startVideoCall() {
+        DoximityDialer.shared.startVideoCall(phoneNumber)
+    }
+
+    private func loadIcon() {
+        do {
+            doximityIcon = try DoximityDialer.shared.doximityIcon()
+        } catch {
+            errorMessage = "Failed to load icon: \(error.localizedDescription)"
+            showError = true
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationView {
+        SwiftUIExampleView()
+    }
+}

--- a/Examples/DoximityDialerExample/DoximityDialerExample/SwiftUIExampleView.swift
+++ b/Examples/DoximityDialerExample/DoximityDialerExample/SwiftUIExampleView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 import DoximityDialerSDK
 
 struct SwiftUIExampleView: View {
@@ -6,14 +7,13 @@ struct SwiftUIExampleView: View {
     @State private var doximityIcon: UIImage?
     @State private var showError = false
     @State private var errorMessage = ""
-
-    private let isDoximityInstalled = DoximityDialer.shared.isDoximityInstalled
+    @State private var isDoximityInstalled = DoximityDialer.shared.isDoximityInstalled
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 24) {
+            VStack(spacing: 0) {
                 // Header
-                VStack(spacing: 16) {
+                VStack(spacing: 20) {
                     if let icon = doximityIcon {
                         Image(uiImage: icon)
                             .resizable()
@@ -21,98 +21,119 @@ struct SwiftUIExampleView: View {
                             .frame(width: 80, height: 80)
                     }
 
-                    Text(isDoximityInstalled ? "✓ Doximity is installed" : "Doximity is not installed")
-                        .font(.body)
-                        .foregroundColor(isDoximityInstalled ? .green : .orange)
+                    Text(isDoximityInstalled ? "✓ Doximity is installed" : "Doximity is not installed\nInstall it to make calls")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(isDoximityInstalled ? .green : .red)
+                        .multilineTextAlignment(.center)
                 }
                 .padding(.top, 40)
+                .padding(.bottom, 40)
 
                 // Phone Number Input
-                TextField("Enter phone number", text: $phoneNumber)
-                    .textFieldStyle(.roundedBorder)
-                    .keyboardType(.phonePad)
-                    .autocorrectionDisabled()
-                    .padding(.horizontal, 32)
+                VStack(spacing: 0) {
+                    TextField("Enter phone number", text: $phoneNumber)
+                        .textFieldStyle(.roundedBorder)
+                        .keyboardType(.phonePad)
+                        .autocorrectionDisabled()
+                        .frame(height: 50)
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 24)
 
                 // Action Buttons
-                VStack(spacing: 16) {
+                VStack(spacing: 12) {
                     Button {
                         dialNumber()
                     } label: {
                         Text("Call with Doximity (Prefill)")
-                            .font(.system(size: 18, weight: .semibold))
+                            .font(.system(size: 16, weight: .semibold))
                             .foregroundColor(.white)
                             .frame(maxWidth: .infinity)
                             .frame(height: 56)
                             .background(Color.blue)
                             .cornerRadius(12)
                     }
+                    .disabled(!isDoximityInstalled)
+                    .opacity(isDoximityInstalled ? 1.0 : 0.5)
 
                     Button {
                         startVoiceCall()
                     } label: {
                         Text("Start Voice Call")
-                            .font(.system(size: 18, weight: .semibold))
+                            .font(.system(size: 16, weight: .semibold))
                             .foregroundColor(.white)
                             .frame(maxWidth: .infinity)
                             .frame(height: 56)
                             .background(Color.green)
                             .cornerRadius(12)
                     }
+                    .disabled(!isDoximityInstalled)
+                    .opacity(isDoximityInstalled ? 1.0 : 0.5)
 
                     Button {
                         startVideoCall()
                     } label: {
                         Text("Start Video Call")
-                            .font(.system(size: 18, weight: .semibold))
+                            .font(.system(size: 16, weight: .semibold))
                             .foregroundColor(.white)
                             .frame(maxWidth: .infinity)
                             .frame(height: 56)
                             .background(Color.purple)
                             .cornerRadius(12)
                     }
-                }
-                .padding(.horizontal, 32)
+                    .disabled(!isDoximityInstalled)
+                    .opacity(isDoximityInstalled ? 1.0 : 0.5)
 
-                Spacer(minLength: 40)
+                    if !isDoximityInstalled {
+                        Button {
+                            installDoximity()
+                        } label: {
+                            Text("Install Doximity")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundColor(.white)
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 56)
+                                .background(Color.orange)
+                                .cornerRadius(12)
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 40)
 
                 // Description
-                VStack(spacing: 16) {
+                VStack(spacing: 0) {
                     Text("This example demonstrates the DoximityDialerSDK in SwiftUI.")
-                        .font(.system(size: 14))
+                        .font(.system(size: 12))
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
+                        .padding(.bottom, 8)
 
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Prefill: Opens Doximity with the number, letting the user choose call type.")
-                            .font(.system(size: 14))
-                            .foregroundColor(.secondary)
+                    Text("Prefill: Opens Doximity with the number, letting the user choose call type.\nVoice/Video: Automatically starts the selected call type.")
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.bottom, 8)
 
-                        Text("Voice/Video: Automatically starts the selected call type.")
-                            .font(.system(size: 14))
-                            .foregroundColor(.secondary)
-                    }
-                    .multilineTextAlignment(.center)
-
-                    VStack(spacing: 4) {
+                    VStack(spacing: 0) {
                         Text("Phone numbers can be formatted any way:")
-                            .font(.system(size: 14))
+                            .font(.system(size: 12))
                             .foregroundColor(.secondary)
 
                         Text("• 5551234567")
-                            .font(.system(size: 14))
+                            .font(.system(size: 12))
                             .foregroundColor(.secondary)
 
                         Text("• (555) 123-4567")
-                            .font(.system(size: 14))
+                            .font(.system(size: 12))
                             .foregroundColor(.secondary)
 
                         Text("• +1 (555) 123-4567")
-                            .font(.system(size: 14))
+                            .font(.system(size: 12))
                             .foregroundColor(.secondary)
                     }
                 }
-                .padding(.horizontal, 40)
+                .padding(.horizontal, 20)
                 .padding(.bottom, 40)
             }
         }
@@ -125,21 +146,46 @@ struct SwiftUIExampleView: View {
         }
         .onAppear {
             loadIcon()
+            updateInstallationStatus()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+            updateInstallationStatus()
         }
     }
 
     // MARK: - Actions
 
     private func dialNumber() {
+        guard !phoneNumber.isEmpty else {
+            errorMessage = "Please enter a phone number"
+            showError = true
+            return
+        }
         DoximityDialer.shared.dialPhoneNumber(phoneNumber)
     }
 
     private func startVoiceCall() {
+        guard !phoneNumber.isEmpty else {
+            errorMessage = "Please enter a phone number"
+            showError = true
+            return
+        }
         DoximityDialer.shared.startVoiceCall(phoneNumber)
     }
 
     private func startVideoCall() {
+        guard !phoneNumber.isEmpty else {
+            errorMessage = "Please enter a phone number"
+            showError = true
+            return
+        }
         DoximityDialer.shared.startVideoCall(phoneNumber)
+    }
+
+    private func installDoximity() {
+        // When Doximity is not installed, any dial method redirects to the App Store
+        // We can use any method to trigger the installation flow
+        DoximityDialer.shared.dialPhoneNumber("")
     }
 
     private func loadIcon() {
@@ -149,6 +195,10 @@ struct SwiftUIExampleView: View {
             errorMessage = "Failed to load icon: \(error.localizedDescription)"
             showError = true
         }
+    }
+
+    private func updateInstallationStatus() {
+        isDoximityInstalled = DoximityDialer.shared.isDoximityInstalled
     }
 }
 

--- a/Examples/DoximityDialerExample/README.md
+++ b/Examples/DoximityDialerExample/README.md
@@ -14,12 +14,12 @@ This unified example app includes:
 
 ### SDK Features Demonstrated
 
-✅ Installation status checking
-✅ Prefill mode (let user choose call type)
-✅ Auto-start voice calls
-✅ Auto-start video calls
-✅ Icon loading and display
-✅ Proper Info.plist configuration
+- ✅ Installation status checking
+- ✅ Prefill mode (let user choose call type)
+- ✅ Auto-start voice calls
+- ✅ Auto-start video calls
+- ✅ Icon loading and display
+- ✅ Proper Info.plist configuration
 
 ## Running the Example
 

--- a/Examples/DoximityDialerExample/README.md
+++ b/Examples/DoximityDialerExample/README.md
@@ -1,0 +1,96 @@
+# Doximity Dialer SDK Example
+
+A complete iOS example app demonstrating DoximityDialerSDK integration in **SwiftUI**, **UIKit (Swift)**, and **UIKit (Objective-C)**.
+
+## Features
+
+This unified example app includes:
+
+- **Main Menu** - Choose between SwiftUI, UIKit (Swift), or UIKit (Objective-C) examples
+- **SwiftUI Example** - Modern declarative UI implementation
+- **UIKit (Swift) Example** - Complete implementation in UIKit with Swift
+- **UIKit (Objective-C) Example** - Complete implementation in UIKit with Objective-C
+- **Swift/ObjC Interoperability** - Demonstrates mixing both languages in one project
+
+### SDK Features Demonstrated
+
+✅ Installation status checking
+✅ Prefill mode (let user choose call type)
+✅ Auto-start voice calls
+✅ Auto-start video calls
+✅ Icon loading and display
+✅ Proper Info.plist configuration
+
+## Running the Example
+
+1. Open `DoximityDialerExample.xcodeproj` in Xcode
+2. Select a simulator or device
+3. Build and run (⌘R)
+4. Choose "SwiftUI Example", "UIKit (Swift) Example", or "UIKit (Objective-C) Example" from the main menu
+
+The project uses a local package reference so it will always use the latest version from your local checkout.
+
+## Project Structure
+
+```
+DoximityDialerExample/
+├── AppDelegate.swift
+├── SceneDelegate.swift
+├── MainMenuViewController.swift          # Main menu (UIKit)
+├── SwiftUIExampleView.swift              # SwiftUI implementation
+├── SwiftExampleViewController.swift      # UIKit Swift implementation
+├── ObjCExampleViewController.h/m         # UIKit Objective-C implementation
+├── DoximityDialerExample-Bridging-Header.h
+├── Info.plist                            # With LSApplicationQueriesSchemes & UILaunchScreen
+└── Assets.xcassets/
+```
+
+## Info.plist Configuration
+
+⚠️ **Critical**: The `Info.plist` includes the required `LSApplicationQueriesSchemes` configuration:
+
+```xml
+<key>LSApplicationQueriesSchemes</key>
+<array>
+    <string>doximity</string>
+</array>
+```
+
+Without this, `isDoximityInstalled` will always return `false`.
+
+## Swift/Objective-C Interop
+
+This project demonstrates how to mix SwiftUI, UIKit (Swift), and UIKit (Objective-C) in a single app:
+
+- SwiftUI views can use UIHostingController to integrate with UIKit navigation
+- Swift files can import Objective-C headers via the bridging header
+- Objective-C files can import Swift-generated headers with `@import`
+- The main menu (UIKit) navigates to SwiftUI, Swift, and Objective-C view controllers
+
+This is valuable for vendors integrating the SDK into existing apps with mixed UI frameworks and languages.
+
+## Troubleshooting
+
+### "Missing package product 'DoximityDialerSDK'" Error
+
+If you see this error when opening the project:
+
+1. **File → Add Package Dependencies...**
+2. Click **"Add Local..."**
+3. Navigate to and select the `CallWithDoxDialer` root directory
+4. Click **"Add Package"**
+
+### Build Errors
+
+If you encounter build errors:
+
+- Clean the build folder: **Product → Clean Build Folder** (⇧⌘K)
+- Delete DerivedData
+- Restart Xcode
+
+## Next Steps
+
+1. Run the app and explore both examples
+2. Review the source code to understand the integration patterns
+3. Copy the relevant patterns into your own app
+4. Don't forget to configure your Info.plist!

--- a/README.md
+++ b/README.md
@@ -13,23 +13,46 @@ Doximity lets healthcare professionals make phone calls to patients while on the
 
 This µLibrary lets 3rd-party apps easily initiate calls through the Doximity app.
 
-## Other Platforms
+**Requirements:** iOS 15.0+
 
-* [Android](https://github.com/doximity/android-dialer-call-lib)
+## ⚠️ Required Configuration
+
+**Before using this SDK, you MUST configure your app's Info.plist:**
+
+Add `doximity` to your `LSApplicationQueriesSchemes` array, or the SDK will not work correctly.
+
+<img src="ReadmeResources/InfoPlistExample.png" height="100"/>
+
+In your app's `Info.plist`, add a new entry with key `LSApplicationQueriesSchemes` (or `Queried URL Schemes`) and value type `Array` if one does not already exist. Then add an element to the array of type `String` and value `doximity`.
+
+**Without this configuration:**
+- `isDoximityInstalled` will always return `false`
+- Users will always be redirected to the App Store, even if Doximity is installed
+- Calls will not work
+
+## Integrating DoximityDialerSDK Into Your App
+
+### Swift Package Manager (SPM)
+
+DoximityDialerSDK is distributed via Swift Package Manager. To use this library in your project, add the https://github.com/doximity/CallWithDoxDialer.git repository as a Swift Package.
+
+### Manually
+To integrate `DoximityDialerSDK` without a package manager, download the following files and place them anywhere in your project:
+- `Sources/DoximityDialerSDK/DoximityDialer.swift`
+- `Sources/DoximityDialerSDK/DoximityDialerSDK.bundle`
 
 ## Usage
+
+All methods accept phone numbers in various formats:
+- Numbers only: `6502333444`
+- Formatted: `(650)233-3444`
 
 ### Core Functionality
 To initiate a call using Doximity, simply call the `dialPhoneNumber` method on the shared `DoximityDialer` instance.
 If the Doximity app is not installed, this call will direct the user to Doximity on the App Store.
 
-Most reasonable phone number formats are accepted by the `dialPhoneNumber` method, e.g.:
-- using numbers only: `6502333444`
-- formatted: `(650)233-3444`
-- with a leading international area code: `+1(650)233-3444`
-
-#### Using Swift
-```
+#### Swift
+```swift
 import DoximityDialerSDK
 
 ...
@@ -37,45 +60,86 @@ import DoximityDialerSDK
 DoximityDialer.shared.dialPhoneNumber("4254443333")
 ```
 
-#### Using Objective-C
-```
-@import DoximityDialerSDK
+#### Objective-C
+```objc
+@import DoximityDialerSDK;
 
 ...
 
 [DoximityDialer dialPhoneNumber:@"4254443333"];
 ```
 
+### Auto-Starting Calls
+You can automatically start a voice or video call instead of prefilling the number:
+
+#### Swift
+```swift
+// Start a voice call immediately
+DoximityDialer.shared.startVoiceCall("4254443333")
+
+// Start a video call immediately
+DoximityDialer.shared.startVideoCall("4254443333")
+```
+
+#### Objective-C
+```objc
+// Start a voice call immediately
+[DoximityDialer startVoiceCall:@"4254443333"];
+
+// Start a video call immediately
+[DoximityDialer startVideoCall:@"4254443333"];
+```
+
+### Checking Installation Status
+You can check if the Doximity app is installed to conditionally show/hide UI elements:
+
+#### Swift
+```swift
+if DoximityDialer.shared.isDoximityInstalled {
+    // Show "Call with Doximity" button
+} else {
+    // Hide button or show "Install Doximity" prompt
+}
+```
+
+#### Objective-C
+```objc
+if ([DoximityDialer isDoximityInstalled]) {
+    // Show "Call with Doximity" button
+} else {
+    // Hide button or show "Install Doximity" prompt
+}
+```
+
 ### Icons
-The library also includes a version of the Doximity icon appropriate for use inside buttons.
-It's available through
-- `DoximityDialer.shared.dialerIcon()`
-- `DoximityDialer.shared.dialerIconAsTemplate()` (for use in tinted views)
+The library includes the Doximity icon for use in buttons. These methods throw errors if the icon cannot be loaded, so use try/catch:
 
+#### Swift
+```swift
+do {
+    let icon = try DoximityDialer.shared.doximityIcon()
+    // Or for tinted views:
+    let templateIcon = try DoximityDialer.shared.doximityIconAsTemplate()
+} catch {
+    print("Failed to load Doximity icon: \(error)")
+}
+```
 
+#### Objective-C
+```objc
+NSError *error = nil;
+UIImage *icon = [DoximityDialer doximityIcon:&error];
+if (error) {
+    NSLog(@"Failed to load Doximity icon: %@", error);
+}
 
-## Integrating DoximityDialerSDK Into Your App
+// Or for tinted views:
+UIImage *templateIcon = [DoximityDialer doximityIconAsTemplate:&error];
+```
 
-DoximityDialerSDK supports iOS 15.0+.
+## Other Platforms
 
-First, you must give your app permission to open the Doximity app.
-
-<img src="ReadmeResources/InfoPlistExample.png" height="100"/>
-
-In your app's `Info.plist`, add a new entry with key `LSApplicationQueriesSchemes` (or `Queried URL Schemes`) and value type `Array` if one does not already exist.
-Then add an element to the array of type `String` and value `doximity`.
-
-
-#### Swift Package Manager (SPM)
-
-DoximityDialerSDK is now distributed via Swift Package Manager. To use this library in your project, add the https://github.com/doximity/CallWithDoxDialer.git repository as a Swift Pacakge.
-
-
-#### Manually
-To integrate `DoximityDialerSDK` without a package manager, simply download the following files, and place it anywhere in your project:
-- `Sources/DoximityDialerSDK/DoximityDialer.swift`
-- `Sources/DoximityDialerSDK/DoximityDialer.bundle`
-
+* [Android](https://github.com/doximity/android-dialer-call-lib)
 
 ## Have a question?
 If you need any help, please reach out! <dialer@doximity.com>.

--- a/README.md
+++ b/README.md
@@ -128,14 +128,31 @@ do {
 #### Objective-C
 ```objc
 NSError *error = nil;
-UIImage *icon = [DoximityDialer doximityIcon:&error];
+UIImage *icon = [DoximityDialer doximityIconAndReturnError:&error];
 if (error) {
     NSLog(@"Failed to load Doximity icon: %@", error);
 }
 
 // Or for tinted views:
-UIImage *templateIcon = [DoximityDialer doximityIconAsTemplate:&error];
+UIImage *templateIcon = [DoximityDialer doximityIconAsTemplateAndReturnError:&error];
 ```
+
+## Example App
+
+A complete example application is available in the [`Examples/`](Examples/) directory:
+
+**[DoximityDialerExample](Examples/DoximityDialerExample/)** - A unified iOS app demonstrating the SDK in SwiftUI, UIKit (Swift), and UIKit (Objective-C).
+
+The example includes:
+- **Main menu** to choose between SwiftUI, UIKit (Swift), or UIKit (Objective-C) examples
+- **SwiftUI implementation** - Modern declarative UI example
+- **UIKit (Swift) implementation** - Complete UIKit integration example
+- **UIKit (Objective-C) implementation** - Complete Objective-C example
+- **SwiftUI/UIKit/ObjC interop** - Shows how to mix all frameworks and languages
+- Proper Info.plist configuration
+- Installation status checking
+- All call types (prefill, voice, video)
+- Icon loading and display
 
 ## Other Platforms
 

--- a/Sources/DoximityDialerSDK/DoximityDialer.swift
+++ b/Sources/DoximityDialerSDK/DoximityDialer.swift
@@ -4,7 +4,15 @@ import UIKit
 /// A struct to handle dialing phone numbers using the Doximity app.
 public struct DoximityDialer {
     /// Singleton instance of `DoximityDialer`.
-    public static let shared = DoximityDialer()
+    public private(set) static var shared = DoximityDialer()
+
+    #if DEBUG
+    /// Replaces the shared instance with a custom instance for testing. Only available in DEBUG builds.
+    /// - Parameter instance: The test instance to use, or nil to reset to default
+    static func setSharedInstance(_ instance: DoximityDialer?) {
+        shared = instance ?? DoximityDialer()
+    }
+    #endif
 
     /// Errors that can occur when using `DoximityDialer`.
     public enum DoximityDialerError: Error {
@@ -22,26 +30,7 @@ public struct DoximityDialer {
         static let queryItemTargetNumberKey = "target_number"
     }
 
-    private let _application: OpenApplicationURL
-
-    private var application: OpenApplicationURL {
-        #if DEBUG
-        if let testApplication = Self._testApplication {
-            return testApplication
-        }
-        #endif
-        return _application
-    }
-
-    #if DEBUG
-    private static var _testApplication: OpenApplicationURL?
-
-    /// Configures a test application for the shared instance. Only available in DEBUG builds.
-    /// - Parameter application: The mock application to use for testing, or nil to reset to default
-    static func setTestApplication(_ application: OpenApplicationURL?) {
-        _testApplication = application
-    }
-    #endif
+    private let application: OpenApplicationURL
 
     /// Options for how Doximity Dialer should handle the phone number.
     enum Options: Equatable {
@@ -66,7 +55,7 @@ public struct DoximityDialer {
     }
 
     init(application: OpenApplicationURL = UIApplication.shared) {
-        self._application = application
+        self.application = application
     }
 
     /// Prefills a phone number into Doximity Dialer, allowing the user to select the type of call.

--- a/Sources/DoximityDialerSDK/DoximityDialer.swift
+++ b/Sources/DoximityDialerSDK/DoximityDialer.swift
@@ -164,15 +164,27 @@ private extension DoximityDialer {
 /// Objective-C compatible class for `DoximityDialer`. Used for bridging with Objective-C codebases.
 @objc(DoximityDialer)
 public final class DoximityDialerObjc: NSObject {
-    /// Dials a phone number using Doximity Dialer.
+    /// Prefills a phone number into Doximity Dialer, allow the user to select why type of call to preform.
     ///
-    /// If the Doximity app is installed, opens Doximity Dialer with the specified phone number and options.
+    /// If the Doximity app is installed, opens Doximity Dialer with the specified phone number.
+    /// If the Doximity app is not installed, redirects the user to the App Store to download Doximity.
+    ///
+    /// - Parameter phoneNumber: The phone number to dial (e.g., "5551234567")
+    @objc public static func dialPhoneNumber(_ phoneNumber: String) {
+        DoximityDialer.shared.dialPhoneNumber(phoneNumber, options: .prefill)
+    }
+
+    /// Dials a phone number using Doximity Dialer and automatically starts a call.
+    ///
+    /// If the Doximity app is installed, opens Doximity Dialer with the specified phone number.
     /// If the Doximity app is not installed, redirects the user to the App Store to download Doximity.
     ///
     /// - Parameters:
     ///   - phoneNumber: The phone number to dial (e.g., "5551234567")
-    @objc public static func dialPhoneNumber(_ phoneNumber: String) {
-        DoximityDialer.shared.dialPhoneNumber(phoneNumber)
+    ///   - kind: The type of call to initiate (`.voice` or `.video`)
+    @objc(dialPhoneNumber:kind:)
+    public static func dialPhoneNumber(_ phoneNumber: String, kind: DoximityDialer.Options.Kind) {
+        DoximityDialer.shared.dialPhoneNumber(phoneNumber, options: .startCall(kind))
     }
 
     /// Returns the Doximity icon image.

--- a/Sources/DoximityDialerSDK/DoximityDialer.swift
+++ b/Sources/DoximityDialerSDK/DoximityDialer.swift
@@ -22,7 +22,26 @@ public struct DoximityDialer {
         static let queryItemTargetNumberKey = "target_number"
     }
 
-    private let application: OpenApplicationURL
+    private let _application: OpenApplicationURL
+
+    private var application: OpenApplicationURL {
+        #if DEBUG
+        if let testApplication = Self._testApplication {
+            return testApplication
+        }
+        #endif
+        return _application
+    }
+
+    #if DEBUG
+    private static var _testApplication: OpenApplicationURL?
+
+    /// Configures a test application for the shared instance. Only available in DEBUG builds.
+    /// - Parameter application: The mock application to use for testing, or nil to reset to default
+    static func setTestApplication(_ application: OpenApplicationURL?) {
+        _testApplication = application
+    }
+    #endif
 
     /// Options for how Doximity Dialer should handle the phone number.
     enum Options: Equatable {
@@ -47,7 +66,7 @@ public struct DoximityDialer {
     }
 
     init(application: OpenApplicationURL = UIApplication.shared) {
-        self.application = application
+        self._application = application
     }
 
     /// Prefills a phone number into Doximity Dialer, allowing the user to select the type of call.

--- a/Sources/DoximityDialerSDK/DoximityDialer.swift
+++ b/Sources/DoximityDialerSDK/DoximityDialer.swift
@@ -140,22 +140,17 @@ private extension DoximityDialer {
     /// Doximity icon asset from the swift package resources
     var iconFromPackage: UIImage? {
     #if SWIFT_PACKAGE
-        guard
-            let image = UIImage(
-                named: "icon",
-                in: .module,
-                compatibleWith: nil
-            )
-        else {
-            return UIImage()
-        }
-        return image
+        return UIImage(
+            named: "icon",
+            in: .module,
+            compatibleWith: nil
+        )
     #else
         return nil
     #endif
     }
 
-    /// Doximity icon asset from the `CallWithDoxDialer.bundle` for manual integration
+    /// Doximity icon asset from the `DoximityDialerSDK.bundle` for manual integration
     var iconFromBundle: UIImage? {
         let libraryBundle = Bundle.main
         guard let assetsBundleURL = libraryBundle.url(forResource: "DoximityDialerSDK", withExtension: "bundle") else {
@@ -168,7 +163,16 @@ private extension DoximityDialer {
     }
 
     /// Checks if the Doximity app is installed on the device.
-    var isDoximityInstalled: Bool {
+    ///
+    /// Use this property to conditionally display UI elements or provide different user experiences
+    /// based on whether Doximity is available. For example, you might show or hide a "Call with Doximity"
+    /// button depending on the installation status.
+    ///
+    /// - Note: Your app must include `doximity` in the `LSApplicationQueriesSchemes` array in Info.plist
+    ///         for this property to work correctly. Without this configuration, the property will always return `false`.
+    ///
+    /// - Returns: `true` if the Doximity app is installed and can be opened, `false` otherwise.
+    public var isDoximityInstalled: Bool {
         guard let doximitySchemeURL = URL(string: Constants.doximityScheme) else {
             return false
         }
@@ -222,6 +226,20 @@ public final class DoximityDialerObjc: NSObject {
     /// - Parameter phoneNumber: The phone number to call (e.g., "5551234567")
     @objc public static func startVideoCall(_ phoneNumber: String) {
         DoximityDialer.shared.startVideoCall(phoneNumber)
+    }
+
+    /// Checks if the Doximity app is installed on the device.
+    ///
+    /// Use this method to conditionally display UI elements or provide different user experiences
+    /// based on whether Doximity is available. For example, you might show or hide a "Call with Doximity"
+    /// button depending on the installation status.
+    ///
+    /// - Note: Your app must include `doximity` in the `LSApplicationQueriesSchemes` array in Info.plist
+    ///         for this method to work correctly. Without this configuration, the method will always return `false`.
+    ///
+    /// - Returns: `true` if the Doximity app is installed and can be opened, `false` otherwise.
+    @objc public static func isDoximityInstalled() -> Bool {
+        DoximityDialer.shared.isDoximityInstalled
     }
 
     /// Returns the Doximity icon image.

--- a/Sources/DoximityDialerSDK/DoximityDialer.swift
+++ b/Sources/DoximityDialerSDK/DoximityDialer.swift
@@ -15,7 +15,7 @@ public struct DoximityDialer {
         static let doximityScheme = "doximity://"
         static let dialerTargetNumberPath = "dialer/call?target_number="
         static let appsFlyerID = "id393642611"
-        static let budnleID = Bundle.main.bundleIdentifier ?? "com.doximity.dialersdk"
+        static let bundleID = Bundle.main.bundleIdentifier ?? "com.doximity.dialersdk"
     }
 
     private let application: OpenApplicationURL
@@ -29,7 +29,7 @@ public struct DoximityDialer {
     /// - Parameter phoneNumber: The 10-digit phone number `String` to dial
     public func dialPhoneNumber(_ phoneNumber: String) {
         if isDoximityInstalled {
-            guard let dialerURL = URL(string: "\(Constants.doximityScheme)\(Constants.dialerTargetNumberPath)\(phoneNumber)&utm_source=\(Constants.budnleID)") else { return }
+            guard let dialerURL = URL(string: "\(Constants.doximityScheme)\(Constants.dialerTargetNumberPath)\(phoneNumber)&utm_source=\(Constants.bundleID)") else { return }
             openURL(dialerURL)
         } else {
             guard let url = doximityAppStoreURL else { return }

--- a/Sources/DoximityDialerSDK/DoximityDialer.swift
+++ b/Sources/DoximityDialerSDK/DoximityDialer.swift
@@ -15,7 +15,6 @@ public struct DoximityDialer {
     /// Constants used in `DoximityDialer`.
     private enum Constants {
         static let doximityScheme = "doximity://"
-        static let dialerTargetNumberPath = "dialer/call?target_number="
         static let appsFlyerID = "id393642611"
         static let bundleID = Bundle.main.bundleIdentifier ?? "com.doximity.dialersdk"
     }

--- a/Sources/DoximityDialerSDK/DoximityDialer.swift
+++ b/Sources/DoximityDialerSDK/DoximityDialer.swift
@@ -12,11 +12,14 @@ public struct DoximityDialer {
         case imageAssetNotFound
     }
 
-    /// Constants used in `DoximityDialer`.
     private enum Constants {
-        static let doximityScheme = "doximity://"
+        static let doximityName = "doximity"
+        static let doximityScheme = "\(doximityName)://"
         static let appsFlyerID = "id393642611"
         static let bundleID = Bundle.main.bundleIdentifier ?? "com.doximity.dialersdk"
+        static let basePath = "/dialer/call"
+        static let queryItemSourceKey = "utm_source"
+        static let queryItemTargetNumberKey = "target_number"
     }
 
     private let application: OpenApplicationURL
@@ -38,13 +41,9 @@ public struct DoximityDialer {
         case startCall(Kind)
 
         var path: String {
-            let base = "/dialer/call"
-
-            return switch self {
-            case .prefill:
-                base
-            case let .startCall(kind):
-                "\(base)/\(kind.rawValue)"
+            switch self {
+            case .prefill: Constants.basePath
+            case let .startCall(kind): "\(Constants.basePath)/\(kind.rawValue)"
             }
         }
     }
@@ -70,11 +69,11 @@ public struct DoximityDialer {
         }
 
         var components = URLComponents()
-        components.scheme = "doximity"
+        components.scheme = Constants.doximityName
         components.path = options.path
         components.queryItems = [
-            URLQueryItem(name: "target_number", value: phoneNumber),
-            URLQueryItem(name: "utm_source", value: Constants.bundleID)
+            URLQueryItem(name: Constants.queryItemTargetNumberKey, value: phoneNumber),
+            URLQueryItem(name: Constants.queryItemSourceKey, value: Constants.bundleID),
         ]
 
         openURL(components.url)

--- a/Sources/DoximityDialerSDK/DoximityDialer.swift
+++ b/Sources/DoximityDialerSDK/DoximityDialer.swift
@@ -20,20 +20,58 @@ public struct DoximityDialer {
 
     private let application: OpenApplicationURL
 
+    /// Options for how Doximity Dialer should handle the phone number.
+    public enum Options: Equatable {
+        /// The type of call to initiate.
+        public enum Kind: String, Equatable {
+            /// Voice call
+            case voice
+            /// Video call
+            case video
+        }
+
+        /// Prefills the phone number in Doximity Dialer without automatically starting the call.
+        case prefill
+
+        /// Automatically starts a call in Doximity Dialer of the specified `Kind`.
+        case startCall(Kind)
+
+        var path: String {
+            let base = "/dialer/call"
+
+            return switch self {
+            case .prefill:
+                base
+            case let .startCall(kind):
+                "\(base)/\(kind.rawValue)"
+            }
+        }
+    }
+
     init(application: OpenApplicationURL = UIApplication.shared) {
         self.application = application
     }
 
     /// Dials a phone number using the Doximity app if it's installed; otherwise,
     /// it directs the user to the App Store page for the Doximity app.
-    /// - Parameter phoneNumber: The 10-digit phone number `String` to dial
-    public func dialPhoneNumber(_ phoneNumber: String) {
-        if isDoximityInstalled {
-            let dialerURL = URL(string: "\(Constants.doximityScheme)\(Constants.dialerTargetNumberPath)\(phoneNumber)&utm_source=\(Constants.bundleID)")
-            openURL(dialerURL)
-        } else {
+    /// - Parameters:
+    ///   - phoneNumber: The 10-digit phone number `String` to dial
+    ///   - options: The dialing option (prefill, voice call, or video call). Defaults to `.prefill`
+    public func dialPhoneNumber(_ phoneNumber: String, options: Options = .prefill) {
+        guard isDoximityInstalled else {
             openURL(doximityAppStoreURL)
+            return
         }
+
+        var components = URLComponents()
+        components.scheme = "doximity"
+        components.path = options.path
+        components.queryItems = [
+            URLQueryItem(name: "target_number", value: phoneNumber),
+            URLQueryItem(name: "utm_source", value: Constants.bundleID)
+        ]
+
+        openURL(components.url)
     }
 
     /// Returns the Doximity icon image.

--- a/Sources/DoximityDialerSDK/DoximityDialer.swift
+++ b/Sources/DoximityDialerSDK/DoximityDialer.swift
@@ -111,6 +111,23 @@ public struct DoximityDialer {
         openURL(components?.url)
     }
 
+    /// Checks if the Doximity app is installed on the device.
+    ///
+    /// Use this property to conditionally display UI elements or provide different user experiences
+    /// based on whether Doximity is available. For example, you might show or hide a "Call with Doximity"
+    /// button depending on the installation status.
+    ///
+    /// - Note: Your app must include `doximity` in the `LSApplicationQueriesSchemes` array in Info.plist
+    ///         for this property to work correctly. Without this configuration, the property will always return `false`.
+    ///
+    /// - Returns: `true` if the Doximity app is installed and can be opened, `false` otherwise.
+    public var isDoximityInstalled: Bool {
+        guard let doximitySchemeURL = URL(string: Constants.doximityScheme) else {
+            return false
+        }
+        return application.canOpenURL(doximitySchemeURL)
+    }
+
     /// Returns the Doximity icon image.
     ///
     /// - Returns: The Doximity icon as a `UIImage`.
@@ -160,23 +177,6 @@ private extension DoximityDialer {
         let doximityIcon = UIImage(named: "icon", in: assetsBundle, with: nil)
 
         return doximityIcon
-    }
-
-    /// Checks if the Doximity app is installed on the device.
-    ///
-    /// Use this property to conditionally display UI elements or provide different user experiences
-    /// based on whether Doximity is available. For example, you might show or hide a "Call with Doximity"
-    /// button depending on the installation status.
-    ///
-    /// - Note: Your app must include `doximity` in the `LSApplicationQueriesSchemes` array in Info.plist
-    ///         for this property to work correctly. Without this configuration, the property will always return `false`.
-    ///
-    /// - Returns: `true` if the Doximity app is installed and can be opened, `false` otherwise.
-    public var isDoximityInstalled: Bool {
-        guard let doximitySchemeURL = URL(string: Constants.doximityScheme) else {
-            return false
-        }
-        return application.canOpenURL(doximitySchemeURL)
     }
 
     /// URL for the Doximity app in the App Store, including app-specific parameters for tracking.

--- a/Sources/DoximityDialerSDK/DoximityDialer.swift
+++ b/Sources/DoximityDialerSDK/DoximityDialer.swift
@@ -23,7 +23,6 @@ public struct DoximityDialer {
     private enum Constants {
         static let doximityName = "doximity"
         static let doximityScheme = "\(doximityName)://"
-        static let appsFlyerID = "id393642611"
         static let bundleID = Bundle.main.bundleIdentifier ?? "com.doximity.dialersdk"
         static let basePath = "dialer/call"
         static let queryItemSourceKey = "utm_source"
@@ -183,7 +182,8 @@ private extension DoximityDialer {
     var doximityAppStoreURL: URL? {
         let appName: String = Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String ?? "Unknown"
         let appIdentifyingName = appName.replacingOccurrences(of: " ", with: "-")
-        return URL(string: "https://app.appsflyer.com/\(Constants.appsFlyerID)?pid=third_party_app&c=\(appIdentifyingName)")
+
+        return URL(string: "https://doximity.sng.link/Az2j3/c17w?_dl=https://www.doximity.com/dialer/home&_smtype=3&pid=third_party_app&c=\(appIdentifyingName)")
     }
 
     /// Opens a given URL using the provided `UIApplication`.

--- a/Sources/DoximityDialerSDK/DoximityDialer.swift
+++ b/Sources/DoximityDialerSDK/DoximityDialer.swift
@@ -29,11 +29,10 @@ public struct DoximityDialer {
     /// - Parameter phoneNumber: The 10-digit phone number `String` to dial
     public func dialPhoneNumber(_ phoneNumber: String) {
         if isDoximityInstalled {
-            guard let dialerURL = URL(string: "\(Constants.doximityScheme)\(Constants.dialerTargetNumberPath)\(phoneNumber)&utm_source=\(Constants.bundleID)") else { return }
+            let dialerURL = URL(string: "\(Constants.doximityScheme)\(Constants.dialerTargetNumberPath)\(phoneNumber)&utm_source=\(Constants.bundleID)")
             openURL(dialerURL)
         } else {
-            guard let url = doximityAppStoreURL else { return }
-            openURL(url)
+            openURL(doximityAppStoreURL)
         }
     }
 
@@ -101,7 +100,8 @@ private extension DoximityDialer {
     }
 
     /// Opens a given URL using the provided `UIApplication`.
-    func openURL(_ url: URL) {
+    func openURL(_ url: URL?) {
+        guard let url else { return }
         application.open(url, options: [:], completionHandler: nil)
     }
 }

--- a/Sources/DoximityDialerSDK/DoximityDialer.swift
+++ b/Sources/DoximityDialerSDK/DoximityDialer.swift
@@ -6,7 +6,9 @@ public struct DoximityDialer {
     /// Singleton instance of `DoximityDialer`.
     public static let shared = DoximityDialer()
 
+    /// Errors that can occur when using `DoximityDialer`.
     public enum DoximityDialerError: Error {
+        /// The Doximity icon image asset could not be found in the SDK bundle or package resources.
         case imageAssetNotFound
     }
 
@@ -52,11 +54,16 @@ public struct DoximityDialer {
         self.application = application
     }
 
-    /// Dials a phone number using the Doximity app if it's installed; otherwise,
-    /// it directs the user to the App Store page for the Doximity app.
+    /// Dials a phone number using Doximity Dialer.
+    ///
+    /// If the Doximity app is installed, opens Doximity Dialer with the specified phone number and options.
+    /// If the Doximity app is not installed, redirects the user to the App Store to download Doximity.
+    ///
     /// - Parameters:
-    ///   - phoneNumber: The 10-digit phone number `String` to dial
-    ///   - options: The dialing option (prefill, voice call, or video call). Defaults to `.prefill`
+    ///   - phoneNumber: The phone number to dial (e.g., "5551234567")
+    ///   - options: How to handle the phone number. Defaults to `.prefill` which opens the Doximity Dialer
+    ///              without automatically starting the call. Use `.startCall(.voice)` or `.startCall(.video)`
+    ///              to automatically initiate a voice or video call.
     public func dialPhoneNumber(_ phoneNumber: String, options: Options = .prefill) {
         guard isDoximityInstalled else {
             openURL(doximityAppStoreURL)
@@ -75,6 +82,9 @@ public struct DoximityDialer {
     }
 
     /// Returns the Doximity icon image.
+    ///
+    /// - Returns: The Doximity icon as a `UIImage`.
+    /// - Throws: `DoximityDialerError.imageAssetNotFound` if the icon cannot be loaded from the SDK resources.
     public func doximityIcon() throws -> UIImage {
         guard let image = iconFromPackage ?? iconFromBundle else {
             throw DoximityDialerError.imageAssetNotFound
@@ -83,6 +93,11 @@ public struct DoximityDialer {
     }
 
     /// Returns the Doximity icon image as a template for UI customization.
+    ///
+    /// The returned image uses `.alwaysTemplate` rendering mode, allowing you to tint it with your app's colors.
+    ///
+    /// - Returns: The Doximity icon as a template `UIImage`.
+    /// - Throws: `DoximityDialerError.imageAssetNotFound` if the icon cannot be loaded from the SDK resources.
     public func doximityIconAsTemplate() throws -> UIImage {
         guard let image = iconFromPackage ?? iconFromBundle else {
             throw DoximityDialerError.imageAssetNotFound
@@ -149,17 +164,31 @@ private extension DoximityDialer {
 /// Objective-C compatible class for `DoximityDialer`. Used for bridging with Objective-C codebases.
 @objc(DoximityDialer)
 public final class DoximityDialerObjc: NSObject {
+    /// Dials a phone number using Doximity Dialer.
+    ///
+    /// If the Doximity app is installed, opens Doximity Dialer with the specified phone number and options.
+    /// If the Doximity app is not installed, redirects the user to the App Store to download Doximity.
+    ///
+    /// - Parameters:
+    ///   - phoneNumber: The phone number to dial (e.g., "5551234567")
     @objc public static func dialPhoneNumber(_ phoneNumber: String) {
         DoximityDialer.shared.dialPhoneNumber(phoneNumber)
     }
 
-    /// Objective-C bridging function that returns the Doximity icon image.
+    /// Returns the Doximity icon image.
+    ///
+    /// - Returns: The Doximity icon as a `UIImage`.
+    /// - Throws: `DoximityDialerError.imageAssetNotFound` if the icon cannot be loaded from the SDK resources.
     @objc public static func doximityIcon() throws -> UIImage {
         try DoximityDialer.shared.doximityIcon()
     }
 
-    /// Objective-C bridging function that returns the Doximity
-    /// icon image as a template for UI customization.
+    /// Returns the Doximity icon image as a template for UI customization.
+    ///
+    /// The returned image uses `.alwaysTemplate` rendering mode, allowing you to tint it with your app's colors.
+    ///
+    /// - Returns: The Doximity icon as a template `UIImage`.
+    /// - Throws: `DoximityDialerError.imageAssetNotFound` if the icon cannot be loaded from the SDK resources.
     @objc public static func doximityIconAsTemplate() throws -> UIImage {
         try DoximityDialer.shared.doximityIconAsTemplate()
     }

--- a/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
+++ b/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
@@ -4,62 +4,44 @@ import Testing
 
 @Suite("DoximityDialer Tests", .serialized)
 struct DoximityDialerSDKTests {
+    var application = MockApplication()
+
+    init() {
+        DoximityDialer.setSharedInstance(DoximityDialer(application: application))
+    }
 
     // MARK: - dialPhoneNumber Tests
 
     @Test("Dials with prefill option when Doximity is installed")
     func dialPhoneNumberWithPrefill() {
-        let mockApplication = MockApplication()
-        mockApplication.canOpenURL = true
-        let dialerCaller = DoximityDialer(application: mockApplication)
-
-        dialerCaller.dialPhoneNumber("5551234567")
-
-        #expect(mockApplication.lastURL == URL(string: "doximity://dialer/call?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+        DoximityDialer.shared.dialPhoneNumber("5551234567")
+        #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
     }
 
     @Test("Starts a voice call")
     func startVoiceCall() {
-        let mockApplication = MockApplication()
-        mockApplication.canOpenURL = true
-        let dialerCaller = DoximityDialer(application: mockApplication)
-
-        dialerCaller.startVoiceCall("5551234567")
-
-        #expect(mockApplication.lastURL == URL(string: "doximity://dialer/call/voice?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+        DoximityDialer.shared.startVoiceCall("5551234567")
+        #expect(application.lastURL == URL(string: "doximity://dialer/call/voice?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
     }
 
     @Test("Starts a video call")
     func startVideoCall() {
-        let mockApplication = MockApplication()
-        mockApplication.canOpenURL = true
-        let dialerCaller = DoximityDialer(application: mockApplication)
-
-        dialerCaller.startVideoCall("5551234567")
-
-        #expect(mockApplication.lastURL == URL(string: "doximity://dialer/call/video?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+        DoximityDialer.shared.startVideoCall("5551234567")
+        #expect(application.lastURL == URL(string: "doximity://dialer/call/video?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
     }
 
     @Test("Redirects to App Store when Doximity is not installed")
     func dialPhoneNumberWhenNotInstalled() {
-        let mockApplication = MockApplication()
-        mockApplication.canOpenURL = false
-        let dialerCaller = DoximityDialer(application: mockApplication)
+        application.canOpenURL = false
 
-        dialerCaller.dialPhoneNumber("5551234567")
-
-        #expect(mockApplication.lastURL == URL(string: "https://app.appsflyer.com/id393642611?pid=third_party_app&c=Unknown"))
+        DoximityDialer.shared.dialPhoneNumber("5551234567")
+        #expect(application.lastURL == URL(string: "https://app.appsflyer.com/id393642611?pid=third_party_app&c=Unknown"))
     }
 
     @Test("URL encodes special characters in phone number")
     func dialPhoneNumberWithSpecialCharacters() {
-        let mockApplication = MockApplication()
-        mockApplication.canOpenURL = true
-        let dialerCaller = DoximityDialer(application: mockApplication)
-
-        dialerCaller.dialPhoneNumber("+1 (555) 123-4567")
-
-        #expect(mockApplication.lastURL == URL(string: "doximity://dialer/call?target_number=+1%20(555)%20123-4567&utm_source=com.apple.dt.xctest.tool"))
+        DoximityDialer.shared.dialPhoneNumber("+1 (555) 123-4567")
+        #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=+1%20(555)%20123-4567&utm_source=com.apple.dt.xctest.tool"))
     }
 
     // MARK: - Options Tests
@@ -95,73 +77,43 @@ struct DoximityDialerSDKTests {
 
     @Test("Objective-C bridge dials with prefill")
     func objcBridgePrefill() {
-        let mockApplication = MockApplication()
-        mockApplication.canOpenURL = true
-        DoximityDialer.setTestApplication(mockApplication)
-        defer { DoximityDialer.setTestApplication(nil) }
-
         DoximityDialerObjc.dialPhoneNumber("5551234567")
-
-        #expect(mockApplication.lastURL == URL(string: "doximity://dialer/call?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+        #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
     }
 
     @Test("Objective-C bridge starts voice call")
     func objcBridgeStartVoiceCall() {
-        let mockApplication = MockApplication()
-        mockApplication.canOpenURL = true
-        DoximityDialer.setTestApplication(mockApplication)
-        defer { DoximityDialer.setTestApplication(nil) }
-
         DoximityDialerObjc.startVoiceCall("5551234567")
-
-        #expect(mockApplication.lastURL == URL(string: "doximity://dialer/call/voice?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+        #expect(application.lastURL == URL(string: "doximity://dialer/call/voice?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
     }
 
     @Test("Objective-C bridge starts video call")
     func objcBridgeStartVideoCall() {
-        let mockApplication = MockApplication()
-        mockApplication.canOpenURL = true
-        DoximityDialer.setTestApplication(mockApplication)
-        defer { DoximityDialer.setTestApplication(nil) }
-
         DoximityDialerObjc.startVideoCall("5551234567")
-
-        #expect(mockApplication.lastURL == URL(string: "doximity://dialer/call/video?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+        #expect(application.lastURL == URL(string: "doximity://dialer/call/video?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
     }
 
     // MARK: - Icon Tests
 
     @Test("Returns Doximity icon image")
     func doximityIcon() throws {
-        let mockApplication = MockApplication()
-        let dialerCaller = DoximityDialer(application: mockApplication)
-
-        let image = try dialerCaller.doximityIcon()
-
-        #expect(image != nil)
+        _ = try DoximityDialer.shared.doximityIcon()
     }
 
     @Test("Returns Doximity icon as template")
     func doximityIconAsTemplate() throws {
-        let mockApplication = MockApplication()
-        let dialerCaller = DoximityDialer(application: mockApplication)
-
-        let image = try dialerCaller.doximityIconAsTemplate()
-
-        #expect(image != nil)
+        let image = try DoximityDialer.shared.doximityIconAsTemplate()
         #expect(image.renderingMode == .alwaysTemplate)
     }
 
     @Test("Objective-C bridge returns icon")
     func objcBridgeIcon() throws {
-        let image = try DoximityDialerObjc.doximityIcon()
-        #expect(image != nil)
+        _ = try DoximityDialerObjc.doximityIcon()
     }
 
     @Test("Objective-C bridge returns icon as template")
     func objcBridgeIconAsTemplate() throws {
         let image = try DoximityDialerObjc.doximityIconAsTemplate()
-        #expect(image != nil)
         #expect(image.renderingMode == .alwaysTemplate)
     }
 }

--- a/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
+++ b/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
@@ -44,6 +44,20 @@ class `Doximity Dialer Tests` {
         }
     }
 
+    class `Installation Check`: `Doximity Dialer Tests` {
+        @Test
+        func `Returns true when Doximity is installed`() {
+            application.canOpenURL = true
+            #expect(DoximityDialer.shared.isDoximityInstalled == true)
+        }
+
+        @Test
+        func `Returns false when Doximity is not installed`() {
+            application.canOpenURL = false
+            #expect(DoximityDialer.shared.isDoximityInstalled == false)
+        }
+    }
+
     class `Objective C Bridge`: `Doximity Dialer Tests` {
         @Test
         func `Dials with prefill`() {
@@ -72,6 +86,18 @@ class `Doximity Dialer Tests` {
         func `Returns icon as template`() throws {
             let image = try DoximityDialerObjc.doximityIconAsTemplate()
             #expect(image.renderingMode == .alwaysTemplate)
+        }
+
+        @Test
+        func `Checks if Doximity is installed`() {
+            application.canOpenURL = true
+            #expect(DoximityDialerObjc.isDoximityInstalled() == true)
+        }
+
+        @Test
+        func `Checks if Doximity is not installed`() {
+            application.canOpenURL = false
+            #expect(DoximityDialerObjc.isDoximityInstalled() == false)
         }
     }
 

--- a/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
+++ b/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
@@ -2,107 +2,107 @@ import Foundation
 import Testing
 @testable import DoximityDialerSDK
 
-@Suite("DoximityDialer Tests", .serialized)
-class DoximityDialerSDKTests {
+@Suite(.serialized)
+class `Doximity Dialer Tests` {
     let application = MockApplication()
 
     init() {
         DoximityDialer.setSharedInstance(DoximityDialer(application: application))
     }
 
-    class CoreFunctionality: DoximityDialerSDKTests {
-        @Test("Dials with prefill option when Doximity is installed")
-        func dialPhoneNumberWithPrefill() {
+    class `Core Functionality`: `Doximity Dialer Tests` {
+        @Test
+        func `Dials with prefill option when Doximity is installed`() {
             DoximityDialer.shared.dialPhoneNumber("5551234567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
         }
 
-        @Test("Starts a voice call")
-        func startVoiceCall() {
+        @Test
+        func `Starts a voice call`() {
             DoximityDialer.shared.startVoiceCall("5551234567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call/voice?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
         }
 
-        @Test("Starts a video call")
-        func startVideoCall() {
+        @Test
+        func `Starts a video call`() {
             DoximityDialer.shared.startVideoCall("5551234567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call/video?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
         }
 
-        @Test("Redirects to App Store when Doximity is not installed")
-        func dialPhoneNumberWhenNotInstalled() {
+        @Test
+        func `Redirects to App Store when Doximity is not installed`() {
             application.canOpenURL = false
 
             DoximityDialer.shared.dialPhoneNumber("5551234567")
             #expect(application.lastURL == URL(string: "https://app.appsflyer.com/id393642611?pid=third_party_app&c=Unknown"))
         }
 
-        @Test("URL encodes special characters in phone number")
-        func dialPhoneNumberWithSpecialCharacters() {
+        @Test
+        func `URL encodes special characters in phone number`() {
             DoximityDialer.shared.dialPhoneNumber("+1 (555) 123-4567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=+1%20(555)%20123-4567&utm_source=com.apple.dt.xctest.tool"))
         }
     }
 
-    class ObjCBridge: DoximityDialerSDKTests {
-        @Test("Dials with prefill")
-        func dialPhoneNumber() {
+    class `Objective C Bridge`: `Doximity Dialer Tests` {
+        @Test
+        func `Dials with prefill`() {
             DoximityDialerObjc.dialPhoneNumber("5551234567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
         }
 
-        @Test("Starts voice call")
-        func startVoiceCall() {
+        @Test
+        func `Starts voice call`() {
             DoximityDialerObjc.startVoiceCall("5551234567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call/voice?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
         }
 
-        @Test("Starts video call")
-        func startVideoCall() {
+        @Test
+        func `Starts video call`() {
             DoximityDialerObjc.startVideoCall("5551234567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call/video?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
         }
 
-        @Test("Returns icon")
-        func doximityIcon() throws {
+        @Test
+        func `Returns icon`() throws {
             _ = try DoximityDialerObjc.doximityIcon()
         }
 
-        @Test("Returns icon as template")
-        func doximityIconAsTemplate() throws {
+        @Test
+        func `Returns icon as template`() throws {
             let image = try DoximityDialerObjc.doximityIconAsTemplate()
             #expect(image.renderingMode == .alwaysTemplate)
         }
     }
 
-    class Icon: DoximityDialerSDKTests {
-        @Test("Returns Doximity icon image")
-        func doximityIcon() throws {
+    class Icon: `Doximity Dialer Tests` {
+        @Test
+        func `Returns Doximity icon image`() throws {
             _ = try DoximityDialer.shared.doximityIcon()
         }
 
-        @Test("Returns Doximity icon as template")
-        func doximityIconAsTemplate() throws {
+        @Test
+        func `Returns Doximity icon as template`() throws {
             let image = try DoximityDialer.shared.doximityIconAsTemplate()
             #expect(image.renderingMode == .alwaysTemplate)
         }
     }
 
-    class Options: DoximityDialerSDKTests {
-        @Test("Prefill path is correct")
-        func prefillPath() {
+    class Options: `Doximity Dialer Tests` {
+        @Test
+        func `Prefill path is correct`() {
             let options = DoximityDialer.Options.prefill
             #expect(options.path == "dialer/call")
         }
 
-        @Test("Start voice call path is correct")
-        func startVoiceCallPath() {
+        @Test
+        func `Start voice call path is correct`() {
             let options = DoximityDialer.Options.startCall(.voice)
             #expect(options.path == "dialer/call/voice")
         }
 
-        @Test("Start video call path is correct")
-        func startVideoCallPath() {
+        @Test
+        func `Start video call path is correct`() {
             let options = DoximityDialer.Options.startCall(.video)
             #expect(options.path == "dialer/call/video")
         }

--- a/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
+++ b/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
@@ -34,7 +34,7 @@ class `Doximity Dialer Tests` {
             application.canOpenURL = false
 
             DoximityDialer.shared.dialPhoneNumber("5551234567")
-            #expect(application.lastURL == URL(string: "https://app.appsflyer.com/id393642611?pid=third_party_app&c=Unknown"))
+            #expect(application.lastURL == URL(string: "https://doximity.sng.link/Az2j3/c17w?_dl=https://www.doximity.com/dialer/home&_smtype=3&pid=third_party_app&c=Unknown"))
         }
 
         @Test

--- a/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
+++ b/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
@@ -3,34 +3,34 @@ import Testing
 @testable import DoximityDialerSDK
 
 @Suite(.serialized)
-class `Doximity Dialer Tests` {
+class DoximityDialerTests {
     let application = MockApplication()
 
     init() {
         DoximityDialer.setSharedInstance(DoximityDialer(application: application))
     }
 
-    class `Core Functionality`: `Doximity Dialer Tests` {
+    class CoreFunctionality: DoximityDialerTests {
         @Test
-        func `Dials with prefill`() {
+        func testDialsWithPrefill() {
             DoximityDialer.shared.dialPhoneNumber("5551234567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
         }
 
         @Test
-        func `Starts voice call`() {
+        func testStartsVoiceCall() {
             DoximityDialer.shared.startVoiceCall("5551234567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call/voice?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
         }
 
         @Test
-        func `Starts video call`() {
+        func testStartsVideoCall() {
             DoximityDialer.shared.startVideoCall("5551234567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call/video?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
         }
 
         @Test
-        func `Redirects when not installed`() {
+        func testRedirectsWhenNotInstalled() {
             application.canOpenURL = false
 
             DoximityDialer.shared.dialPhoneNumber("5551234567")
@@ -38,97 +38,97 @@ class `Doximity Dialer Tests` {
         }
 
         @Test
-        func `Encodes special characters`() {
+        func testEncodesSpecialCharacters() {
             DoximityDialer.shared.dialPhoneNumber("+1 (555) 123-4567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=+1%20(555)%20123-4567&utm_source=com.apple.dt.xctest.tool"))
         }
     }
 
-    class `Installation Check`: `Doximity Dialer Tests` {
+    class InstallationCheck: DoximityDialerTests {
         @Test
-        func `Returns true when installed`() {
+        func testReturnsTrueWhenInstalled() {
             application.canOpenURL = true
             #expect(DoximityDialer.shared.isDoximityInstalled == true)
         }
 
         @Test
-        func `Returns false when not installed`() {
+        func testReturnsFalseWhenNotInstalled() {
             application.canOpenURL = false
             #expect(DoximityDialer.shared.isDoximityInstalled == false)
         }
     }
 
-    class Icon: `Doximity Dialer Tests` {
+    class Icon: DoximityDialerTests {
         @Test
-        func `Returns icon`() throws {
+        func testReturnsIcon() throws {
             _ = try DoximityDialer.shared.doximityIcon()
         }
 
         @Test
-        func `Returns icon as template`() throws {
+        func testReturnsIconAsTemplate() throws {
             let image = try DoximityDialer.shared.doximityIconAsTemplate()
             #expect(image.renderingMode == .alwaysTemplate)
         }
     }
 
-    class Options: `Doximity Dialer Tests` {
+    class Options: DoximityDialerTests {
         @Test
-        func `Prefill path`() {
+        func testPrefillPath() {
             let options = DoximityDialer.Options.prefill
             #expect(options.path == "dialer/call")
         }
 
         @Test
-        func `Voice call path`() {
+        func testVoiceCallPath() {
             let options = DoximityDialer.Options.startCall(.voice)
             #expect(options.path == "dialer/call/voice")
         }
 
         @Test
-        func `Video call path`() {
+        func testVideoCallPath() {
             let options = DoximityDialer.Options.startCall(.video)
             #expect(options.path == "dialer/call/video")
         }
     }
 
-    class `Objective C Bridge`: `Doximity Dialer Tests` {
+    class ObjectiveCBridge: DoximityDialerTests {
         @Test
-        func `Dials with prefill`() {
+        func testDialsWithPrefill() {
             DoximityDialerObjc.dialPhoneNumber("5551234567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
         }
 
         @Test
-        func `Starts voice call`() {
+        func testStartsVoiceCall() {
             DoximityDialerObjc.startVoiceCall("5551234567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call/voice?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
         }
 
         @Test
-        func `Starts video call`() {
+        func testStartsVideoCall() {
             DoximityDialerObjc.startVideoCall("5551234567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call/video?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
         }
 
         @Test
-        func `Returns true when installed`() {
+        func testReturnsTrueWhenInstalled() {
             application.canOpenURL = true
             #expect(DoximityDialerObjc.isDoximityInstalled() == true)
         }
 
         @Test
-        func `Returns false when not installed`() {
+        func testReturnsFalseWhenNotInstalled() {
             application.canOpenURL = false
             #expect(DoximityDialerObjc.isDoximityInstalled() == false)
         }
 
         @Test
-        func `Returns icon`() throws {
+        func testReturnsIcon() throws {
             _ = try DoximityDialerObjc.doximityIcon()
         }
 
         @Test
-        func `Returns icon as template`() throws {
+        func testReturnsIconAsTemplate() throws {
             let image = try DoximityDialerObjc.doximityIconAsTemplate()
             #expect(image.renderingMode == .alwaysTemplate)
         }

--- a/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
+++ b/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import DoximityDialerSDK
 
-@Suite("DoximityDialer Tests")
+@Suite("DoximityDialer Tests", .serialized)
 struct DoximityDialerSDKTests {
 
     // MARK: - dialPhoneNumber Tests
@@ -89,6 +89,44 @@ struct DoximityDialerSDKTests {
         #expect(DoximityDialer.Options.startCall(.video) == DoximityDialer.Options.startCall(.video))
         #expect(DoximityDialer.Options.prefill != DoximityDialer.Options.startCall(.voice))
         #expect(DoximityDialer.Options.startCall(.voice) != DoximityDialer.Options.startCall(.video))
+    }
+
+    // MARK: - Objective-C Bridge Tests
+
+    @Test("Objective-C bridge dials with prefill")
+    func objcBridgePrefill() {
+        let mockApplication = MockApplication()
+        mockApplication.canOpenURL = true
+        DoximityDialer.setTestApplication(mockApplication)
+        defer { DoximityDialer.setTestApplication(nil) }
+
+        DoximityDialerObjc.dialPhoneNumber("5551234567")
+
+        #expect(mockApplication.lastURL == URL(string: "doximity://dialer/call?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+    }
+
+    @Test("Objective-C bridge starts voice call")
+    func objcBridgeStartVoiceCall() {
+        let mockApplication = MockApplication()
+        mockApplication.canOpenURL = true
+        DoximityDialer.setTestApplication(mockApplication)
+        defer { DoximityDialer.setTestApplication(nil) }
+
+        DoximityDialerObjc.startVoiceCall("5551234567")
+
+        #expect(mockApplication.lastURL == URL(string: "doximity://dialer/call/voice?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+    }
+
+    @Test("Objective-C bridge starts video call")
+    func objcBridgeStartVideoCall() {
+        let mockApplication = MockApplication()
+        mockApplication.canOpenURL = true
+        DoximityDialer.setTestApplication(mockApplication)
+        defer { DoximityDialer.setTestApplication(nil) }
+
+        DoximityDialerObjc.startVideoCall("5551234567")
+
+        #expect(mockApplication.lastURL == URL(string: "doximity://dialer/call/video?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
     }
 
     // MARK: - Icon Tests

--- a/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
+++ b/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
@@ -1,36 +1,129 @@
-import XCTest
+import Foundation
+import Testing
 @testable import DoximityDialerSDK
 
-final class DoximityDialerSDKTests: XCTestCase {
+@Suite("DoximityDialer Tests")
+struct DoximityDialerSDKTests {
 
-    var dialerCaller: DoximityDialer!
-    var mockApplication: MockApplication!
+    // MARK: - dialPhoneNumber Tests
 
-    override func setUp() {
-        super.setUp()
-        mockApplication = MockApplication()
-        dialerCaller = DoximityDialer(application: mockApplication)
+    @Test("Dials with prefill option when Doximity is installed")
+    func dialPhoneNumberWithPrefill() {
+        let mockApplication = MockApplication()
+        mockApplication.canOpenURL = true
+        let dialerCaller = DoximityDialer(application: mockApplication)
+
+        dialerCaller.dialPhoneNumber("5551234567")
+
+        #expect(mockApplication.lastURL == URL(string: "doximity://dialer/call?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
     }
 
-    override func tearDown() {
-        dialerCaller = nil
-        mockApplication = nil
-        super.tearDown()
+    @Test("Starts a voice call")
+    func startVoiceCall() {
+        let mockApplication = MockApplication()
+        mockApplication.canOpenURL = true
+        let dialerCaller = DoximityDialer(application: mockApplication)
+
+        dialerCaller.startVoiceCall("5551234567")
+
+        #expect(mockApplication.lastURL == URL(string: "doximity://dialer/call/voice?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
     }
 
-    func testDialPhoneNumber_WithDoximityNotInstalled_ShouldOpenAppStoreURL() {
-        dialerCaller.dialPhoneNumber("1234567890")
-        XCTAssertEqual(mockApplication.lastURL, URL(string: "doximity://dialer/call?target_number=1234567890&utm_source=com.apple.dt.xctest.tool"))
+    @Test("Starts a video call")
+    func startVideoCall() {
+        let mockApplication = MockApplication()
+        mockApplication.canOpenURL = true
+        let dialerCaller = DoximityDialer(application: mockApplication)
+
+        dialerCaller.startVideoCall("5551234567")
+
+        #expect(mockApplication.lastURL == URL(string: "doximity://dialer/call/video?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
     }
 
-    func testDialPhoneNumber_WithDoximityInstalled_ShouldOpenCorrectURL() {
+    @Test("Redirects to App Store when Doximity is not installed")
+    func dialPhoneNumberWhenNotInstalled() {
+        let mockApplication = MockApplication()
         mockApplication.canOpenURL = false
-        dialerCaller.dialPhoneNumber("1234567890")
-        XCTAssertEqual(mockApplication.lastURL, URL(string: "https://app.appsflyer.com/id393642611?pid=third_party_app&c=Unknown"))
+        let dialerCaller = DoximityDialer(application: mockApplication)
+
+        dialerCaller.dialPhoneNumber("5551234567")
+
+        #expect(mockApplication.lastURL == URL(string: "https://app.appsflyer.com/id393642611?pid=third_party_app&c=Unknown"))
     }
 
-    func testDoximityIcon_ShouldReturnImage() {
-        let image = dialerCaller.doximityIcon
-        XCTAssertNotNil(image)
+    @Test("URL encodes special characters in phone number")
+    func dialPhoneNumberWithSpecialCharacters() {
+        let mockApplication = MockApplication()
+        mockApplication.canOpenURL = true
+        let dialerCaller = DoximityDialer(application: mockApplication)
+
+        dialerCaller.dialPhoneNumber("+1 (555) 123-4567")
+
+        #expect(mockApplication.lastURL == URL(string: "doximity://dialer/call?target_number=+1%20(555)%20123-4567&utm_source=com.apple.dt.xctest.tool"))
+    }
+
+    // MARK: - Options Tests
+
+    @Test("Options prefill path is correct")
+    func optionsPrefillPath() {
+        let options = DoximityDialer.Options.prefill
+        #expect(options.path == "dialer/call")
+    }
+
+    @Test("Options start voice call path is correct")
+    func optionsStartVoiceCallPath() {
+        let options = DoximityDialer.Options.startCall(.voice)
+        #expect(options.path == "dialer/call/voice")
+    }
+
+    @Test("Options start video call path is correct")
+    func optionsStartVideoCallPath() {
+        let options = DoximityDialer.Options.startCall(.video)
+        #expect(options.path == "dialer/call/video")
+    }
+
+    @Test("Options are equatable")
+    func optionsEquatable() {
+        #expect(DoximityDialer.Options.prefill == DoximityDialer.Options.prefill)
+        #expect(DoximityDialer.Options.startCall(.voice) == DoximityDialer.Options.startCall(.voice))
+        #expect(DoximityDialer.Options.startCall(.video) == DoximityDialer.Options.startCall(.video))
+        #expect(DoximityDialer.Options.prefill != DoximityDialer.Options.startCall(.voice))
+        #expect(DoximityDialer.Options.startCall(.voice) != DoximityDialer.Options.startCall(.video))
+    }
+
+    // MARK: - Icon Tests
+
+    @Test("Returns Doximity icon image")
+    func doximityIcon() throws {
+        let mockApplication = MockApplication()
+        let dialerCaller = DoximityDialer(application: mockApplication)
+
+        let image = try dialerCaller.doximityIcon()
+
+        #expect(image != nil)
+    }
+
+    @Test("Returns Doximity icon as template")
+    func doximityIconAsTemplate() throws {
+        let mockApplication = MockApplication()
+        let dialerCaller = DoximityDialer(application: mockApplication)
+
+        let image = try dialerCaller.doximityIconAsTemplate()
+
+        #expect(image != nil)
+        #expect(image.renderingMode == .alwaysTemplate)
+    }
+
+    @Test("Objective-C bridge returns icon")
+    func objcBridgeIcon() throws {
+        let image = try DoximityDialerObjc.doximityIcon()
+        #expect(image != nil)
+    }
+
+    @Test("Objective-C bridge returns icon as template")
+    func objcBridgeIconAsTemplate() throws {
+        let image = try DoximityDialerObjc.doximityIconAsTemplate()
+        #expect(image != nil)
+        #expect(image.renderingMode == .alwaysTemplate)
     }
 }

--- a/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
+++ b/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
@@ -3,117 +3,108 @@ import Testing
 @testable import DoximityDialerSDK
 
 @Suite("DoximityDialer Tests", .serialized)
-struct DoximityDialerSDKTests {
-    var application = MockApplication()
+class DoximityDialerSDKTests {
+    let application = MockApplication()
 
     init() {
         DoximityDialer.setSharedInstance(DoximityDialer(application: application))
     }
 
-    // MARK: - dialPhoneNumber Tests
+    class CoreFunctionality: DoximityDialerSDKTests {
+        @Test("Dials with prefill option when Doximity is installed")
+        func dialPhoneNumberWithPrefill() {
+            DoximityDialer.shared.dialPhoneNumber("5551234567")
+            #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+        }
 
-    @Test("Dials with prefill option when Doximity is installed")
-    func dialPhoneNumberWithPrefill() {
-        DoximityDialer.shared.dialPhoneNumber("5551234567")
-        #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+        @Test("Starts a voice call")
+        func startVoiceCall() {
+            DoximityDialer.shared.startVoiceCall("5551234567")
+            #expect(application.lastURL == URL(string: "doximity://dialer/call/voice?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+        }
+
+        @Test("Starts a video call")
+        func startVideoCall() {
+            DoximityDialer.shared.startVideoCall("5551234567")
+            #expect(application.lastURL == URL(string: "doximity://dialer/call/video?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+        }
+
+        @Test("Redirects to App Store when Doximity is not installed")
+        func dialPhoneNumberWhenNotInstalled() {
+            application.canOpenURL = false
+
+            DoximityDialer.shared.dialPhoneNumber("5551234567")
+            #expect(application.lastURL == URL(string: "https://app.appsflyer.com/id393642611?pid=third_party_app&c=Unknown"))
+        }
+
+        @Test("URL encodes special characters in phone number")
+        func dialPhoneNumberWithSpecialCharacters() {
+            DoximityDialer.shared.dialPhoneNumber("+1 (555) 123-4567")
+            #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=+1%20(555)%20123-4567&utm_source=com.apple.dt.xctest.tool"))
+        }
     }
 
-    @Test("Starts a voice call")
-    func startVoiceCall() {
-        DoximityDialer.shared.startVoiceCall("5551234567")
-        #expect(application.lastURL == URL(string: "doximity://dialer/call/voice?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+    class ObjCBridge: DoximityDialerSDKTests {
+        @Test("Dials with prefill")
+        func dialPhoneNumber() {
+            DoximityDialerObjc.dialPhoneNumber("5551234567")
+            #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+        }
+
+        @Test("Starts voice call")
+        func startVoiceCall() {
+            DoximityDialerObjc.startVoiceCall("5551234567")
+            #expect(application.lastURL == URL(string: "doximity://dialer/call/voice?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+        }
+
+        @Test("Starts video call")
+        func startVideoCall() {
+            DoximityDialerObjc.startVideoCall("5551234567")
+            #expect(application.lastURL == URL(string: "doximity://dialer/call/video?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+        }
+
+        @Test("Returns icon")
+        func doximityIcon() throws {
+            _ = try DoximityDialerObjc.doximityIcon()
+        }
+
+        @Test("Returns icon as template")
+        func doximityIconAsTemplate() throws {
+            let image = try DoximityDialerObjc.doximityIconAsTemplate()
+            #expect(image.renderingMode == .alwaysTemplate)
+        }
     }
 
-    @Test("Starts a video call")
-    func startVideoCall() {
-        DoximityDialer.shared.startVideoCall("5551234567")
-        #expect(application.lastURL == URL(string: "doximity://dialer/call/video?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
+    class Icon: DoximityDialerSDKTests {
+        @Test("Returns Doximity icon image")
+        func doximityIcon() throws {
+            _ = try DoximityDialer.shared.doximityIcon()
+        }
+
+        @Test("Returns Doximity icon as template")
+        func doximityIconAsTemplate() throws {
+            let image = try DoximityDialer.shared.doximityIconAsTemplate()
+            #expect(image.renderingMode == .alwaysTemplate)
+        }
     }
 
-    @Test("Redirects to App Store when Doximity is not installed")
-    func dialPhoneNumberWhenNotInstalled() {
-        application.canOpenURL = false
+    class Options: DoximityDialerSDKTests {
+        @Test("Prefill path is correct")
+        func prefillPath() {
+            let options = DoximityDialer.Options.prefill
+            #expect(options.path == "dialer/call")
+        }
 
-        DoximityDialer.shared.dialPhoneNumber("5551234567")
-        #expect(application.lastURL == URL(string: "https://app.appsflyer.com/id393642611?pid=third_party_app&c=Unknown"))
-    }
+        @Test("Start voice call path is correct")
+        func startVoiceCallPath() {
+            let options = DoximityDialer.Options.startCall(.voice)
+            #expect(options.path == "dialer/call/voice")
+        }
 
-    @Test("URL encodes special characters in phone number")
-    func dialPhoneNumberWithSpecialCharacters() {
-        DoximityDialer.shared.dialPhoneNumber("+1 (555) 123-4567")
-        #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=+1%20(555)%20123-4567&utm_source=com.apple.dt.xctest.tool"))
-    }
-
-    // MARK: - Options Tests
-
-    @Test("Options prefill path is correct")
-    func optionsPrefillPath() {
-        let options = DoximityDialer.Options.prefill
-        #expect(options.path == "dialer/call")
-    }
-
-    @Test("Options start voice call path is correct")
-    func optionsStartVoiceCallPath() {
-        let options = DoximityDialer.Options.startCall(.voice)
-        #expect(options.path == "dialer/call/voice")
-    }
-
-    @Test("Options start video call path is correct")
-    func optionsStartVideoCallPath() {
-        let options = DoximityDialer.Options.startCall(.video)
-        #expect(options.path == "dialer/call/video")
-    }
-
-    @Test("Options are equatable")
-    func optionsEquatable() {
-        #expect(DoximityDialer.Options.prefill == DoximityDialer.Options.prefill)
-        #expect(DoximityDialer.Options.startCall(.voice) == DoximityDialer.Options.startCall(.voice))
-        #expect(DoximityDialer.Options.startCall(.video) == DoximityDialer.Options.startCall(.video))
-        #expect(DoximityDialer.Options.prefill != DoximityDialer.Options.startCall(.voice))
-        #expect(DoximityDialer.Options.startCall(.voice) != DoximityDialer.Options.startCall(.video))
-    }
-
-    // MARK: - Objective-C Bridge Tests
-
-    @Test("Objective-C bridge dials with prefill")
-    func objcBridgePrefill() {
-        DoximityDialerObjc.dialPhoneNumber("5551234567")
-        #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
-    }
-
-    @Test("Objective-C bridge starts voice call")
-    func objcBridgeStartVoiceCall() {
-        DoximityDialerObjc.startVoiceCall("5551234567")
-        #expect(application.lastURL == URL(string: "doximity://dialer/call/voice?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
-    }
-
-    @Test("Objective-C bridge starts video call")
-    func objcBridgeStartVideoCall() {
-        DoximityDialerObjc.startVideoCall("5551234567")
-        #expect(application.lastURL == URL(string: "doximity://dialer/call/video?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
-    }
-
-    // MARK: - Icon Tests
-
-    @Test("Returns Doximity icon image")
-    func doximityIcon() throws {
-        _ = try DoximityDialer.shared.doximityIcon()
-    }
-
-    @Test("Returns Doximity icon as template")
-    func doximityIconAsTemplate() throws {
-        let image = try DoximityDialer.shared.doximityIconAsTemplate()
-        #expect(image.renderingMode == .alwaysTemplate)
-    }
-
-    @Test("Objective-C bridge returns icon")
-    func objcBridgeIcon() throws {
-        _ = try DoximityDialerObjc.doximityIcon()
-    }
-
-    @Test("Objective-C bridge returns icon as template")
-    func objcBridgeIconAsTemplate() throws {
-        let image = try DoximityDialerObjc.doximityIconAsTemplate()
-        #expect(image.renderingMode == .alwaysTemplate)
+        @Test("Start video call path is correct")
+        func startVideoCallPath() {
+            let options = DoximityDialer.Options.startCall(.video)
+            #expect(options.path == "dialer/call/video")
+        }
     }
 }

--- a/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
+++ b/Tests/DoximityDialerSDKTests/DoximityDialerSDKTests.swift
@@ -12,25 +12,25 @@ class `Doximity Dialer Tests` {
 
     class `Core Functionality`: `Doximity Dialer Tests` {
         @Test
-        func `Dials with prefill option when Doximity is installed`() {
+        func `Dials with prefill`() {
             DoximityDialer.shared.dialPhoneNumber("5551234567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
         }
 
         @Test
-        func `Starts a voice call`() {
+        func `Starts voice call`() {
             DoximityDialer.shared.startVoiceCall("5551234567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call/voice?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
         }
 
         @Test
-        func `Starts a video call`() {
+        func `Starts video call`() {
             DoximityDialer.shared.startVideoCall("5551234567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call/video?target_number=5551234567&utm_source=com.apple.dt.xctest.tool"))
         }
 
         @Test
-        func `Redirects to App Store when Doximity is not installed`() {
+        func `Redirects when not installed`() {
             application.canOpenURL = false
 
             DoximityDialer.shared.dialPhoneNumber("5551234567")
@@ -38,7 +38,7 @@ class `Doximity Dialer Tests` {
         }
 
         @Test
-        func `URL encodes special characters in phone number`() {
+        func `Encodes special characters`() {
             DoximityDialer.shared.dialPhoneNumber("+1 (555) 123-4567")
             #expect(application.lastURL == URL(string: "doximity://dialer/call?target_number=+1%20(555)%20123-4567&utm_source=com.apple.dt.xctest.tool"))
         }
@@ -46,15 +46,48 @@ class `Doximity Dialer Tests` {
 
     class `Installation Check`: `Doximity Dialer Tests` {
         @Test
-        func `Returns true when Doximity is installed`() {
+        func `Returns true when installed`() {
             application.canOpenURL = true
             #expect(DoximityDialer.shared.isDoximityInstalled == true)
         }
 
         @Test
-        func `Returns false when Doximity is not installed`() {
+        func `Returns false when not installed`() {
             application.canOpenURL = false
             #expect(DoximityDialer.shared.isDoximityInstalled == false)
+        }
+    }
+
+    class Icon: `Doximity Dialer Tests` {
+        @Test
+        func `Returns icon`() throws {
+            _ = try DoximityDialer.shared.doximityIcon()
+        }
+
+        @Test
+        func `Returns icon as template`() throws {
+            let image = try DoximityDialer.shared.doximityIconAsTemplate()
+            #expect(image.renderingMode == .alwaysTemplate)
+        }
+    }
+
+    class Options: `Doximity Dialer Tests` {
+        @Test
+        func `Prefill path`() {
+            let options = DoximityDialer.Options.prefill
+            #expect(options.path == "dialer/call")
+        }
+
+        @Test
+        func `Voice call path`() {
+            let options = DoximityDialer.Options.startCall(.voice)
+            #expect(options.path == "dialer/call/voice")
+        }
+
+        @Test
+        func `Video call path`() {
+            let options = DoximityDialer.Options.startCall(.video)
+            #expect(options.path == "dialer/call/video")
         }
     }
 
@@ -78,6 +111,18 @@ class `Doximity Dialer Tests` {
         }
 
         @Test
+        func `Returns true when installed`() {
+            application.canOpenURL = true
+            #expect(DoximityDialerObjc.isDoximityInstalled() == true)
+        }
+
+        @Test
+        func `Returns false when not installed`() {
+            application.canOpenURL = false
+            #expect(DoximityDialerObjc.isDoximityInstalled() == false)
+        }
+
+        @Test
         func `Returns icon`() throws {
             _ = try DoximityDialerObjc.doximityIcon()
         }
@@ -86,51 +131,6 @@ class `Doximity Dialer Tests` {
         func `Returns icon as template`() throws {
             let image = try DoximityDialerObjc.doximityIconAsTemplate()
             #expect(image.renderingMode == .alwaysTemplate)
-        }
-
-        @Test
-        func `Checks if Doximity is installed`() {
-            application.canOpenURL = true
-            #expect(DoximityDialerObjc.isDoximityInstalled() == true)
-        }
-
-        @Test
-        func `Checks if Doximity is not installed`() {
-            application.canOpenURL = false
-            #expect(DoximityDialerObjc.isDoximityInstalled() == false)
-        }
-    }
-
-    class Icon: `Doximity Dialer Tests` {
-        @Test
-        func `Returns Doximity icon image`() throws {
-            _ = try DoximityDialer.shared.doximityIcon()
-        }
-
-        @Test
-        func `Returns Doximity icon as template`() throws {
-            let image = try DoximityDialer.shared.doximityIconAsTemplate()
-            #expect(image.renderingMode == .alwaysTemplate)
-        }
-    }
-
-    class Options: `Doximity Dialer Tests` {
-        @Test
-        func `Prefill path is correct`() {
-            let options = DoximityDialer.Options.prefill
-            #expect(options.path == "dialer/call")
-        }
-
-        @Test
-        func `Start voice call path is correct`() {
-            let options = DoximityDialer.Options.startCall(.voice)
-            #expect(options.path == "dialer/call/voice")
-        }
-
-        @Test
-        func `Start video call path is correct`() {
-            let options = DoximityDialer.Options.startCall(.video)
-            #expect(options.path == "dialer/call/video")
         }
     }
 }


### PR DESCRIPTION
## Overview

This PR enhances the DoximityDialerSDK with three new public APIs that give vendors more control over call initiation and installation detection:

New APIs:
- `startVoiceCall(_:)` - Automatically initiates a voice call without user selection.
- `startVideoCall(_:)` - Automatically initiates a video call without user selection.
- `isDoximityInstalled` - Checks if the Doximity app is installed on the device, this already existed just wasn't public. 

Added an example app:
A comprehensive app that demonstrates all SDK features in three implementations:
- SwiftUI
- UIKit (Swift)
- UIKit (Objective-C)

## Technical Detail(s)

- All new methods include full Objective-C support via bridging. The existing dialPhoneNumber(_:) method continues to work as before (prefill mode where the user chooses call type).
- Updated App Store redirect URL from AppsFlyer to Singular
- Migrated tests to Swift Testing framework
- Enhanced documentation with usage examples and warnings

## Breaking Changes

None. All changes are additive. The existing `dialPhoneNumber(_:)` API remains unchanged and fully backward compatible.

## QA Recommendation

Developer QA (not traditional QA) because:

1. SDK/Library nature - This is a developer-facing SDK that requires integration into an app, not a standalone application
2. Example app is the test harness - The included example app demonstrates all functionality and serves as the primary validation tool

Suggested Developer QA Checklist:

- [x] Run SwiftUI example and test all three call methods
- [x] Run UIKit (Swift) example and test all three call methods
- [x] Run UIKit (Objective-C) example and test all three call methods
- [x] Verify installation detection badge shows correct status
- [x] Test with Doximity app installed - verify calls open Doximity correctly
- [x] Test without Doximity app - verify App Store redirect works