### PR TITLE
XCode 26.2 CI Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,14 @@ meta:
   xcode-versions: &xcode-versions
       matrix:
         parameters:
-          xcode-version: ["16.4", "26.0", "26.1"]
+          xcode-version: ["26.0", "26.1", "26.2"]
 
 jobs:
   build_and_test:
     parameters:
       xcode-version:
         type: string
-        default: "26.1"
+        default: "26.2"
     macos:
       xcode: << parameters.xcode-version >>
     resource_class: m4pro.medium


### PR DESCRIPTION
https://doximity.atlassian.net/browse/IA-5414

Adds Xcode 26.2 CI support and removes Xcode 16.4 from the test matrix.