### PR TITLE
CI Support for Xcode 26.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,14 @@ meta:
   xcode-versions: &xcode-versions
       matrix:
         parameters:
-          xcode-version: ["26.0", "26.1", "26.2"]
+          xcode-version: ["26.1", "26.2", "26.3"]
 
 jobs:
   build_and_test:
     parameters:
       xcode-version:
         type: string
-        default: "26.2"
+        default: "26.3"
     macos:
       xcode: << parameters.xcode-version >>
     resource_class: m4pro.medium
@@ -19,24 +19,14 @@ jobs:
       XCODE_VERSION: << parameters.xcode-version >>
     steps:
       - checkout
-      - run: xcodebuild -version
-      - run:
-          name: Set test device
-          command: |
-            # Use iPhone 17 for Xcode 26.x, iPhone 16 otherwise
-            iphone_num="16"
-            if [[ "$XCODE_VERSION" =~ "26" ]]; then
-              iphone_num="17"
-            fi
-            echo "Setting test device to iPhone $iphone_num"
-            echo "export TEST_DEVICE=\"iPhone $iphone_num\"" >> $BASH_ENV
+      - run: xcodebuild -version      
       - run:
           name: Build and Test
           command: |
             fastlane scan \
               --package_path "." \
               --scheme "DoximityDialerSDK" \
-              --device "$TEST_DEVICE" \
+              --device "iPhone 17" \
               --clean --result_bundle true --output-types "junit"
       - run:
           name: Generate Test Results


### PR DESCRIPTION
https://doximity.atlassian.net/browse/IA-5730

https://circleci.com/changelog/xcode-26-3-0-available/

Adjusting the xcode version matrix to include the recently released Xcode 26.3