### PR TITLE
Support Xcode 26.4 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ meta:
   xcode-versions: &xcode-versions
       matrix:
         parameters:
-          xcode-version: ["26.1", "26.2", "26.3"]
+          xcode-version: ["26.2", "26.3", "26.4"]
 
 jobs:
   build_and_test:


### PR DESCRIPTION
https://doximity.atlassian.net/browse/IA-5811

Adds Xcode 26.4 to the CI matrix