### PR TITLE
Support Xcode 26.6 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ meta:
   xcode-versions: &xcode-versions
       matrix:
         parameters:
-          xcode-version: ["26.3", "26.4", "26.5"]
+          xcode-version: ["26.4", "26.5", "26.6"]
 
 jobs:
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     parameters:
       xcode-version:
         type: string
-        default: "26.5"
+        default: "26.6"
     macos:
       xcode: << parameters.xcode-version >>
     resource_class: m4pro.medium


### PR DESCRIPTION
https://doximity.atlassian.net/browse/IA-6230

Adding Xcode 26.6 to CI testing matrix